### PR TITLE
Route evaluator LLM calls through Claude Code via MCP sampling

### DIFF
--- a/apps/mcp-server/src/bin.ts
+++ b/apps/mcp-server/src/bin.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { loadRuntime } from "./runtime.js";
+import { loadRuntime, type ProviderKind } from "./runtime.js";
 import { buildServer } from "./server.js";
+import { buildSamplingDelegate } from "./sampling.js";
 
 /**
  * Entry point for the MCP server stdio transport.
@@ -9,21 +11,57 @@ import { buildServer } from "./server.js";
  * Usage:
  *   claude mcp add networkpipeline -- npx -y @networkpipeline/mcp-server
  *
- * Required env:
- *   ANTHROPIC_API_KEY              — for the evaluator's Claude calls.
+ * Provider selection (NETWORKPIPELINE_PROVIDER):
+ *   "claude_code" — route LLM calls back through Claude Code via MCP
+ *                   sampling. No API key. Billed against Max subscription.
+ *   "anthropic"   — direct Anthropic API calls. Requires ANTHROPIC_API_KEY.
+ *   "auto" (default) — Claude Code when running under an MCP client that
+ *                      supports sampling, Anthropic API otherwise.
  *
  * Optional env:
  *   NETWORKPIPELINE_HOME           — runtime data dir (default ~/.networkpipeline).
  *   NETWORKPIPELINE_CRITERIA_PATH  — override criteria.yaml location.
  *   NETWORKPIPELINE_LOG_PATH       — override mcp_invocations JSONL path.
- *   ANTHROPIC_MODEL                — override Claude model (default claude-opus-4-7).
+ *   NETWORKPIPELINE_PROVIDER       — provider strategy (see above).
+ *   ANTHROPIC_API_KEY              — required only for the "anthropic" path.
+ *   ANTHROPIC_MODEL                — override Claude model for the API path.
  */
 async function main(): Promise<void> {
-  const runtime = await loadRuntime({
-    anthropicModel: process.env.ANTHROPIC_MODEL
+  const providerKind = parseProviderKind(process.env.NETWORKPIPELINE_PROVIDER);
+
+  // Construct the SDK server up front so we can hand its `createMessage`
+  // primitive to the runtime as a SamplingDelegate. This inverts the
+  // previous load-runtime-then-build-server order: sampling is a server-
+  // to-client capability that depends on the SDK server existing first.
+  const sdkServer = new McpServer({
+    name: "networkpipeline",
+    version: "0.1.0"
   });
 
-  const { server } = buildServer({ runtime });
+  const samplingDelegate = buildSamplingDelegate(sdkServer);
+
+  const runtime = await loadRuntime({
+    anthropicModel: process.env.ANTHROPIC_MODEL,
+    providerKind,
+    samplingDelegate
+  });
+
+  // Surface which provider the runtime resolved to, so users can spot
+  // misconfigurations (e.g., expecting the Max-billed path but landing
+  // on the API path because no transport-side sampling is wired). stderr
+  // — stdout is the protocol channel.
+  const resolved = describeProvider(runtime.provider.constructor.name);
+  process.stderr.write(
+    `[networkpipeline mcp-server] provider=${resolved} (kind=${providerKind ?? "auto"})\n`
+  );
+
+  // buildServer is given the existing McpServer to register tools onto,
+  // rather than constructing a fresh one. This keeps the sampling
+  // delegate's reference valid.
+  const { server } = buildServer({
+    runtime,
+    existingServer: sdkServer
+  });
   const transport = new StdioServerTransport();
   await server.connect(transport);
 
@@ -41,6 +79,24 @@ async function main(): Promise<void> {
       });
     });
   }
+}
+
+function parseProviderKind(raw: string | undefined): ProviderKind | undefined {
+  if (!raw) return undefined;
+  const normalized = raw.toLowerCase();
+  if (normalized === "claude_code" || normalized === "anthropic" || normalized === "auto") {
+    return normalized;
+  }
+  process.stderr.write(
+    `[networkpipeline mcp-server] warning: unknown NETWORKPIPELINE_PROVIDER=${raw}, defaulting to auto\n`
+  );
+  return undefined;
+}
+
+function describeProvider(ctorName: string): string {
+  if (ctorName === "ClaudeCodeJsonOutputProvider") return "claude_code";
+  if (ctorName === "AnthropicJsonOutputProvider") return "anthropic";
+  return ctorName;
 }
 
 main().catch((err) => {

--- a/apps/mcp-server/src/runtime.ts
+++ b/apps/mcp-server/src/runtime.ts
@@ -14,7 +14,9 @@ import {
 } from "@networkpipeline/db";
 import {
   AnthropicJsonOutputProvider,
-  type JsonOutputProvider
+  ClaudeCodeJsonOutputProvider,
+  type JsonOutputProvider,
+  type SamplingDelegate
 } from "@networkpipeline/evaluator";
 
 export type Repositories = {
@@ -46,6 +48,23 @@ export type Runtime = {
   criteriaVersionId: string;
 };
 
+/**
+ * Provider selection strategy.
+ *
+ *   - "claude_code": route LLM calls through the user's Claude Code session
+ *     via MCP `sampling/createMessage`. Requires a `samplingDelegate`.
+ *     Inference is billed against the Claude Code Max subscription, so no
+ *     Anthropic API key is needed.
+ *   - "anthropic": call the Anthropic API directly with an API key. Used
+ *     for CI / automation / multi-user contexts where there is no Claude
+ *     Code session driving the work.
+ *   - "auto" (default): pick "claude_code" if a `samplingDelegate` is
+ *     provided, otherwise fall back to "anthropic". This preserves
+ *     backward-compat for existing API-key-based setups while making the
+ *     in-Claude-Code path zero-config when a delegate is wired up.
+ */
+export type ProviderKind = "claude_code" | "anthropic" | "auto";
+
 export type LoadRuntimeOptions = {
   /** Override criteria file path. */
   criteriaPath?: string;
@@ -54,8 +73,20 @@ export type LoadRuntimeOptions = {
   /** Override Anthropic default model. Falls back to evaluator default. */
   anthropicModel?: string;
   /**
-   * Inject a provider instead of constructing the Anthropic adapter.
-   * Used by tests to avoid real API calls.
+   * Provider selection. Defaults to "auto" — see {@link ProviderKind}.
+   * "claude_code" requires `samplingDelegate`. "anthropic" requires a key.
+   */
+  providerKind?: ProviderKind;
+  /**
+   * Sampling delegate used when the resolved provider is "claude_code".
+   * The MCP server constructs this lambda after the SDK's McpServer is
+   * built, since sampling is a server-to-client primitive that depends
+   * on a connected transport.
+   */
+  samplingDelegate?: SamplingDelegate;
+  /**
+   * Inject a provider instead of constructing one. Used by tests to
+   * avoid real API calls.
    */
   providerOverride?: JsonOutputProvider;
   /**
@@ -85,12 +116,7 @@ export async function loadRuntime(
     options.criteriaPath
   );
 
-  const provider =
-    options.providerOverride ??
-    new AnthropicJsonOutputProvider({
-      apiKey: options.anthropicApiKey,
-      defaultModel: options.anthropicModel
-    });
+  const provider = options.providerOverride ?? buildProvider(options);
 
   const connection =
     options.connectionOverride ?? openDb({ path: options.dbPath });
@@ -119,6 +145,53 @@ export async function loadRuntime(
     repositories,
     criteriaVersionId
   };
+}
+
+/**
+ * Resolve a JsonOutputProvider from LoadRuntimeOptions.
+ *
+ * Resolution rules:
+ *   - explicit `providerKind: "claude_code"`: requires `samplingDelegate`,
+ *     throws otherwise.
+ *   - explicit `providerKind: "anthropic"`: constructs the API-key adapter
+ *     (which itself throws if the key is missing).
+ *   - default (`"auto"` or undefined): if a `samplingDelegate` is present,
+ *     prefer Claude Code so users on a Max subscription don't pay twice;
+ *     fall back to the Anthropic API path otherwise.
+ *
+ * Exported for unit tests; production callers go through `loadRuntime`.
+ */
+export function buildProvider(options: LoadRuntimeOptions): JsonOutputProvider {
+  const kind: ProviderKind = options.providerKind ?? "auto";
+
+  if (kind === "claude_code") {
+    if (!options.samplingDelegate) {
+      throw new Error(
+        "loadRuntime: providerKind=claude_code requires a samplingDelegate."
+      );
+    }
+    return new ClaudeCodeJsonOutputProvider({
+      delegate: options.samplingDelegate
+    });
+  }
+
+  if (kind === "anthropic") {
+    return new AnthropicJsonOutputProvider({
+      apiKey: options.anthropicApiKey,
+      defaultModel: options.anthropicModel
+    });
+  }
+
+  // auto: prefer the in-session sampling path when wired, fall back to API.
+  if (options.samplingDelegate) {
+    return new ClaudeCodeJsonOutputProvider({
+      delegate: options.samplingDelegate
+    });
+  }
+  return new AnthropicJsonOutputProvider({
+    apiKey: options.anthropicApiKey,
+    defaultModel: options.anthropicModel
+  });
 }
 
 /**

--- a/apps/mcp-server/src/sampling.ts
+++ b/apps/mcp-server/src/sampling.ts
@@ -1,0 +1,109 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { SamplingDelegate } from "@networkpipeline/evaluator";
+
+/**
+ * Build a SamplingDelegate that routes evaluator LLM calls back into
+ * the connected MCP client (Claude Code) via the `sampling/createMessage`
+ * primitive.
+ *
+ * When the user runs Claude Code with NetworkPipeline registered as an
+ * MCP server, every evaluator stage (extract, values, score) calls
+ * `provider.generateJsonObject(...)` on a `ClaudeCodeJsonOutputProvider`,
+ * which in turn calls this delegate, which sends a `sampling/createMessage`
+ * request back over the stdio transport. Claude Code performs the
+ * inference inside the user's existing Max-subscription session and
+ * returns a `tool_use` content block. We then unwrap that block back
+ * into `{ data, usage }` for the provider to validate.
+ *
+ * The McpServer must be connected to a transport before any sampling
+ * call is dispatched; the delegate is invoked lazily (per evaluator
+ * call), so as long as construction wires up the transport before the
+ * first tool dispatch, ordering is fine.
+ */
+export function buildSamplingDelegate(server: McpServer): SamplingDelegate {
+  return async (req) => {
+    // Tool schema requires `type: "object"` at the top level. The Zod
+    // → JSON Schema conversion already produces that shape for the
+    // schemas we use; we cast through unknown to the SDK's stricter
+    // shape (which requires properties values typed as `object`) since
+    // our JSON schema property values are themselves objects in
+    // practice and zod-to-json-schema keeps them that way.
+    const inputSchema = req.inputSchema as unknown as {
+      [x: string]: unknown;
+      type: "object";
+      properties?: { [x: string]: object };
+      required?: string[];
+    };
+
+    const result = await server.server.createMessage({
+      systemPrompt: req.systemPrompt,
+      maxTokens: req.maxTokens ?? 4096,
+      messages: [
+        {
+          role: "user",
+          content: { type: "text", text: req.userPrompt }
+        }
+      ],
+      tools: [
+        {
+          name: req.toolName,
+          description: req.toolDescription,
+          inputSchema
+        }
+      ],
+      toolChoice: { mode: "required" }
+    });
+
+    // Locate the tool_use content block. With tools provided the result
+    // content can be a single block or an array of blocks (parallel
+    // tool calls); we only ever ask for one tool, so take the first
+    // tool_use we find.
+    const block = pickToolUseBlock(result.content, req.toolName);
+    if (!block) {
+      throw new Error(
+        `sampling/createMessage returned no tool_use block for tool ${req.toolName}.`
+      );
+    }
+
+    return {
+      data: block.input as unknown,
+      usage: {
+        // The MCP sampling result surfaces `model` and `stopReason`,
+        // but does NOT expose token counts — Claude Code keeps usage
+        // accounting on its side. We pass through what's available
+        // and let the provider fill the rest with zero defaults.
+        model: result.model,
+        stop_reason: result.stopReason
+      }
+    };
+  };
+}
+
+type ToolUseBlock = {
+  type: "tool_use";
+  name: string;
+  id: string;
+  input: Record<string, unknown>;
+};
+
+/**
+ * Walk the (possibly array, possibly single-block) content of a
+ * sampling result and return the first matching tool_use block.
+ */
+function pickToolUseBlock(
+  content: unknown,
+  toolName: string
+): ToolUseBlock | undefined {
+  const blocks = Array.isArray(content) ? content : [content];
+  for (const block of blocks) {
+    if (
+      block &&
+      typeof block === "object" &&
+      (block as { type?: unknown }).type === "tool_use" &&
+      (block as { name?: unknown }).name === toolName
+    ) {
+      return block as ToolUseBlock;
+    }
+  }
+  return undefined;
+}

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -25,6 +25,13 @@ export type BuildServerOptions = {
   name?: string;
   /** Override server version (default: package.json). */
   version?: string;
+  /**
+   * Existing McpServer instance to register tools onto. The bin.ts entry
+   * point passes one in so the sampling delegate (which closes over the
+   * server) and the tool registrations share the same SDK server. When
+   * omitted, a fresh server is constructed (used by tests).
+   */
+  existingServer?: McpServer;
 };
 
 /**
@@ -60,10 +67,12 @@ export function buildServer(options: BuildServerOptions) {
   registry.register(makeBulkEvaluateJobsTool(options.runtime));
   registry.register(makeRunSavedSearchTool(options.runtime));
 
-  const server = new McpServer({
-    name: options.name ?? "networkpipeline",
-    version: options.version ?? "0.1.0"
-  });
+  const server =
+    options.existingServer ??
+    new McpServer({
+      name: options.name ?? "networkpipeline",
+      version: options.version ?? "0.1.0"
+    });
 
   for (const tool of registry.list()) {
     // Best-effort introspection of the input shape. Object schemas are

--- a/packages/evaluator/package.json
+++ b/packages/evaluator/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "typecheck": "tsc --project tsconfig.json --noEmit",
-    "test": "node --import tsx --test src/__tests__/schema.test.ts src/__tests__/prompt.test.ts src/__tests__/extract.test.ts src/__tests__/gates.test.ts src/__tests__/pre_extraction.test.ts src/__tests__/values.test.ts src/__tests__/score.test.ts src/__tests__/pipeline.test.ts"
+    "test": "node --import tsx --test src/__tests__/schema.test.ts src/__tests__/prompt.test.ts src/__tests__/extract.test.ts src/__tests__/gates.test.ts src/__tests__/pre_extraction.test.ts src/__tests__/values.test.ts src/__tests__/score.test.ts src/__tests__/pipeline.test.ts src/__tests__/provider_claude_code.test.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/packages/evaluator/src/__tests__/provider_claude_code.test.ts
+++ b/packages/evaluator/src/__tests__/provider_claude_code.test.ts
@@ -1,0 +1,195 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { z } from "zod";
+import {
+  ClaudeCodeJsonOutputProvider,
+  ProviderValidationError,
+  type SamplingDelegate
+} from "../provider/index.js";
+
+const schema = z.object({
+  title: z.string(),
+  count: z.number().int()
+});
+
+type FixtureOutput = z.infer<typeof schema>;
+
+function baseRequest(overrides: Partial<{ model: string; maxRetries: number; maxTokens: number }> = {}) {
+  return {
+    promptId: "test_prompt_v1",
+    systemPrompt: "system instructions",
+    userPrompt: "user message body",
+    outputSchema: schema,
+    toolName: "submit_thing",
+    toolDescription: "Submit the structured thing.",
+    ...overrides
+  } as const;
+}
+
+describe("ClaudeCodeJsonOutputProvider", () => {
+  it("invokes the delegate with the prompt, tool metadata, and converted schema", async () => {
+    const calls: Array<Parameters<SamplingDelegate>[0]> = [];
+    const delegate: SamplingDelegate = async (req) => {
+      calls.push(req);
+      return {
+        data: { title: "ok", count: 3 } satisfies FixtureOutput,
+        usage: {
+          input_tokens: 100,
+          output_tokens: 25,
+          cache_creation_tokens: 5,
+          cache_read_tokens: 50,
+          model: "claude-opus-4-7",
+          stop_reason: "tool_use"
+        }
+      };
+    };
+    const provider = new ClaudeCodeJsonOutputProvider({ delegate });
+    const result = await provider.generateJsonObject(baseRequest());
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.systemPrompt, "system instructions");
+    assert.equal(calls[0]?.userPrompt, "user message body");
+    assert.equal(calls[0]?.toolName, "submit_thing");
+    assert.equal(calls[0]?.toolDescription, "Submit the structured thing.");
+    // The delegate receives a JSON Schema object, not a Zod instance.
+    const schemaObj = calls[0]?.inputSchema as Record<string, unknown>;
+    assert.equal(schemaObj.type, "object");
+    assert.ok(schemaObj.properties);
+    // Default maxTokens default is 4096.
+    assert.equal(calls[0]?.maxTokens, 4096);
+
+    assert.deepEqual(result.data, { title: "ok", count: 3 });
+  });
+
+  it("populates ProviderRun fields from the delegate's usage metadata", async () => {
+    const delegate: SamplingDelegate = async () => ({
+      data: { title: "ok", count: 3 },
+      usage: {
+        input_tokens: 100,
+        output_tokens: 25,
+        cache_creation_tokens: 5,
+        cache_read_tokens: 50,
+        model: "claude-opus-4-7",
+        stop_reason: "end_turn"
+      }
+    });
+    const provider = new ClaudeCodeJsonOutputProvider({ delegate });
+    const result = await provider.generateJsonObject(baseRequest());
+
+    assert.equal(result.run.provider, "claude_code");
+    assert.equal(result.run.model, "claude-opus-4-7");
+    assert.equal(result.run.prompt_id, "test_prompt_v1");
+    assert.equal(result.run.input_tokens, 100);
+    assert.equal(result.run.output_tokens, 25);
+    assert.equal(result.run.cache_creation_tokens, 5);
+    assert.equal(result.run.cache_read_tokens, 50);
+    assert.equal(result.run.cost_usd_cents, null);
+    assert.equal(result.run.stop_reason, "end_turn");
+    assert.equal(result.run.retries, 0);
+    assert.ok(result.run.latency_ms >= 0);
+  });
+
+  it("falls back to defaults when the delegate's usage metadata is empty", async () => {
+    const delegate: SamplingDelegate = async () => ({
+      data: { title: "ok", count: 3 },
+      usage: {}
+    });
+    const provider = new ClaudeCodeJsonOutputProvider({ delegate });
+    const result = await provider.generateJsonObject(baseRequest());
+
+    assert.equal(result.run.provider, "claude_code");
+    assert.equal(result.run.model, "claude-code-session");
+    assert.equal(result.run.input_tokens, 0);
+    assert.equal(result.run.output_tokens, 0);
+    assert.equal(result.run.cache_creation_tokens, 0);
+    assert.equal(result.run.cache_read_tokens, 0);
+    assert.equal(result.run.cost_usd_cents, null);
+    assert.equal(result.run.stop_reason, "tool_use");
+    assert.equal(result.run.retries, 0);
+  });
+
+  it("retries once on Zod validation failure with the schema errors injected into the user prompt", async () => {
+    const seenUserPrompts: string[] = [];
+    let call = 0;
+    const delegate: SamplingDelegate = async (req) => {
+      seenUserPrompts.push(req.userPrompt);
+      call++;
+      if (call === 1) {
+        // Bad: count is a string, schema requires int.
+        return {
+          data: { title: "ok", count: "three" },
+          usage: { input_tokens: 10, output_tokens: 5 }
+        };
+      }
+      return {
+        data: { title: "ok", count: 3 },
+        usage: { input_tokens: 12, output_tokens: 6 }
+      };
+    };
+    const provider = new ClaudeCodeJsonOutputProvider({ delegate });
+    const result = await provider.generateJsonObject(baseRequest());
+
+    assert.equal(call, 2);
+    assert.equal(result.data.count, 3);
+    assert.equal(result.run.retries, 1);
+    // Tokens accumulate across attempts.
+    assert.equal(result.run.input_tokens, 22);
+    assert.equal(result.run.output_tokens, 11);
+
+    // First attempt sees the original prompt.
+    assert.equal(seenUserPrompts[0], "user message body");
+    // Second attempt sees the original plus error feedback.
+    assert.ok(seenUserPrompts[1]?.startsWith("user message body"));
+    assert.ok(seenUserPrompts[1]?.includes("did not match the required schema"));
+    assert.ok(seenUserPrompts[1]?.includes("submit_thing"));
+  });
+
+  it("throws ProviderValidationError after exhausting retries on persistent invalid output", async () => {
+    let calls = 0;
+    const delegate: SamplingDelegate = async () => {
+      calls++;
+      return {
+        data: { title: 42, count: "nope" },
+        usage: {}
+      };
+    };
+    const provider = new ClaudeCodeJsonOutputProvider({ delegate });
+    await assert.rejects(
+      () => provider.generateJsonObject(baseRequest({ maxRetries: 1 })),
+      (err) => {
+        assert.ok(err instanceof ProviderValidationError);
+        assert.equal((err as ProviderValidationError).attempts, 2);
+        return true;
+      }
+    );
+    assert.equal(calls, 2);
+  });
+
+  it("respects the per-request maxRetries override", async () => {
+    let calls = 0;
+    const delegate: SamplingDelegate = async () => {
+      calls++;
+      return { data: {}, usage: {} };
+    };
+    const provider = new ClaudeCodeJsonOutputProvider({ delegate });
+    await assert.rejects(() =>
+      provider.generateJsonObject(baseRequest({ maxRetries: 3 }))
+    );
+    // 3 retries → 4 total attempts.
+    assert.equal(calls, 4);
+  });
+
+  it("forwards the per-request model override to the delegate as modelHint", async () => {
+    let seenHint: string | undefined;
+    const delegate: SamplingDelegate = async (req) => {
+      seenHint = req.modelHint;
+      return {
+        data: { title: "ok", count: 1 },
+        usage: { model: "claude-haiku-4" }
+      };
+    };
+    const provider = new ClaudeCodeJsonOutputProvider({ delegate });
+    await provider.generateJsonObject(baseRequest({ model: "claude-haiku-4" }));
+    assert.equal(seenHint, "claude-haiku-4");
+  });
+});

--- a/packages/evaluator/src/provider/claude_code.ts
+++ b/packages/evaluator/src/provider/claude_code.ts
@@ -1,0 +1,186 @@
+import { zodToJsonSchema } from "zod-to-json-schema";
+import {
+  ProviderValidationError,
+  type JsonOutputProvider,
+  type JsonOutputRequest,
+  type JsonOutputResult,
+  type ProviderRun
+} from "./types.js";
+
+/**
+ * Pluggable hook the runtime injects so this provider has a way to
+ * call back into the live MCP server's `sampling/createMessage`
+ * primitive. We keep the provider package free of MCP SDK imports —
+ * the server (apps/mcp-server) wires this lambda when it constructs
+ * the runtime, so packages remain independently testable with mocks.
+ *
+ * The delegate receives an already-converted JSON schema (Zod →
+ * JSON Schema is done once at the provider boundary so retries do
+ * not re-pay the conversion). It returns the raw tool_use input
+ * (un-validated; the provider validates with Zod) plus best-effort
+ * usage metadata for ProviderRun population.
+ */
+export type SamplingDelegate = (request: {
+  systemPrompt: string;
+  userPrompt: string;
+  toolName: string;
+  toolDescription: string;
+  inputSchema: Record<string, unknown>;
+  modelHint?: string;
+  maxTokens?: number;
+}) => Promise<{
+  /** The raw tool_use input, before Zod validation. */
+  data: unknown;
+  /** Best-effort observability metadata Claude Code surfaces. */
+  usage: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_tokens?: number;
+    cache_read_tokens?: number;
+    model?: string;
+    stop_reason?: string;
+  };
+}>;
+
+export type ClaudeCodeAdapterOptions = {
+  delegate: SamplingDelegate;
+  /** Optional per-adapter retry override. Defaults to 1. */
+  defaultMaxRetries?: number;
+};
+
+/**
+ * ClaudeCodeJsonOutputProvider — routes LLM calls through the user's
+ * Claude Code session via MCP sampling. No Anthropic API key needed;
+ * inference is billed against the existing Claude Code subscription.
+ *
+ * The provider is otherwise identical to AnthropicJsonOutputProvider:
+ * Zod validation on the tool output, retry-once-with-error-feedback,
+ * structured ProviderRun output. Cost reporting is best-effort because
+ * Claude Code doesn't surface dollar amounts to MCP servers — fields
+ * remain null where unknown.
+ */
+export class ClaudeCodeJsonOutputProvider implements JsonOutputProvider {
+  private readonly delegate: SamplingDelegate;
+  private readonly defaultMaxRetries: number;
+
+  constructor(options: ClaudeCodeAdapterOptions) {
+    this.delegate = options.delegate;
+    this.defaultMaxRetries = options.defaultMaxRetries ?? 1;
+  }
+
+  async generateJsonObject<T>(
+    request: JsonOutputRequest<T>
+  ): Promise<JsonOutputResult<T>> {
+    const maxRetries = request.maxRetries ?? this.defaultMaxRetries;
+    const maxAttempts = maxRetries + 1;
+
+    // Convert once outside the loop — the schema is identical across retries.
+    const inputSchema = zodToJsonSchema(request.outputSchema, {
+      $refStrategy: "none",
+      target: "openApi3"
+    }) as Record<string, unknown>;
+
+    let totalInput = 0;
+    let totalOutput = 0;
+    let totalCacheCreate = 0;
+    let totalCacheRead = 0;
+    let lastModel: string | undefined;
+    let lastStopReason: string | undefined;
+    let lastRaw: unknown = null;
+    let lastIssues: unknown = null;
+
+    const startedAt = new Date();
+    const startTs = Date.now();
+
+    let currentUser = request.userPrompt;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const { data: raw, usage } = await this.delegate({
+        systemPrompt: request.systemPrompt,
+        userPrompt: currentUser,
+        toolName: request.toolName,
+        toolDescription: request.toolDescription,
+        inputSchema,
+        modelHint: request.model,
+        maxTokens: request.maxTokens ?? 4096
+      });
+
+      totalInput += usage.input_tokens ?? 0;
+      totalOutput += usage.output_tokens ?? 0;
+      totalCacheCreate += usage.cache_creation_tokens ?? 0;
+      totalCacheRead += usage.cache_read_tokens ?? 0;
+      if (usage.model) lastModel = usage.model;
+      if (usage.stop_reason) lastStopReason = usage.stop_reason;
+
+      lastRaw = raw;
+      const parsed = request.outputSchema.safeParse(raw);
+      if (parsed.success) {
+        return {
+          data: parsed.data,
+          run: this.buildRun({
+            promptId: request.promptId,
+            startedAt,
+            startTs,
+            totalInput,
+            totalOutput,
+            totalCacheCreate,
+            totalCacheRead,
+            model: lastModel,
+            stopReason: lastStopReason,
+            retries: attempt
+          })
+        };
+      }
+      lastIssues = parsed.error.issues;
+
+      if (attempt < maxAttempts - 1) {
+        currentUser = `${request.userPrompt}\n\nYour previous tool call did not match the required schema. Errors:\n${JSON.stringify(
+          parsed.error.issues,
+          null,
+          2
+        )}\n\nCall the \`${request.toolName}\` tool again with corrected input.`;
+      }
+    }
+
+    throw new ProviderValidationError(
+      `Claude Code provider exhausted ${maxAttempts} attempts without valid output.`,
+      maxAttempts,
+      lastRaw,
+      lastIssues
+    );
+  }
+
+  private buildRun(args: {
+    promptId: string;
+    startedAt: Date;
+    startTs: number;
+    totalInput: number;
+    totalOutput: number;
+    totalCacheCreate: number;
+    totalCacheRead: number;
+    model: string | undefined;
+    stopReason: string | undefined;
+    retries: number;
+  }): ProviderRun {
+    return {
+      provider: "claude_code",
+      // When Claude Code surfaces the model id, use it; otherwise we mark
+      // the run with a sentinel so downstream observability can tell it
+      // came from a sampling session rather than a direct API call.
+      model: args.model ?? "claude-code-session",
+      prompt_id: args.promptId,
+      started_at: args.startedAt.toISOString(),
+      latency_ms: Date.now() - args.startTs,
+      input_tokens: args.totalInput,
+      output_tokens: args.totalOutput,
+      cache_creation_tokens: args.totalCacheCreate,
+      cache_read_tokens: args.totalCacheRead,
+      // Cost is intentionally null: Claude Code does not surface dollar
+      // amounts to MCP servers, and the call is billed against the user's
+      // Max subscription rather than per-token API spend.
+      cost_usd_cents: null,
+      stop_reason: args.stopReason ?? "tool_use",
+      retries: args.retries
+    };
+  }
+}

--- a/packages/evaluator/src/provider/index.ts
+++ b/packages/evaluator/src/provider/index.ts
@@ -13,3 +13,9 @@ export {
   DEFAULT_ANTHROPIC_MODEL,
   type AnthropicAdapterOptions
 } from "./anthropic.js";
+
+export {
+  ClaudeCodeJsonOutputProvider,
+  type ClaudeCodeAdapterOptions,
+  type SamplingDelegate
+} from "./claude_code.js";


### PR DESCRIPTION
## Summary

Removes the per-token Anthropic API billing surface for evaluator LLM calls when running under Claude Code. Inference now flows through the user's existing Max subscription via MCP sampling — zero additional cost.

## What changed

- **New provider** \`ClaudeCodeJsonOutputProvider\` in \`packages/evaluator/src/provider/claude_code.ts\`. Same \`JsonOutputProvider\` interface as the Anthropic adapter (Zod validation, retry-on-failure, structured \`ProviderRun\`). Takes a \`SamplingDelegate\` lambda; the package has zero MCP-SDK imports.
- **Sampling boundary** in new \`apps/mcp-server/src/sampling.ts\`. Single point of contact with \`server.createMessage\` (the SDK's server-to-client primitive). Verified the MCP SDK ^1.0.0 supports it including tool-use return blocks.
- **Runtime selection** in \`apps/mcp-server/src/runtime.ts\`: new \`providerKind: \"claude_code\" | \"anthropic\" | \"auto\"\` (default \"auto\"). Auto picks claude_code when a sampling delegate is wired, anthropic otherwise.
- **Bin entry** inverted: build SDK server first, attach sampling delegate, hand to \`loadRuntime\`, then \`buildServer\` registers tools onto the same SDK server. Boot logs which provider was resolved.
- \`AnthropicJsonOutputProvider\` is preserved unchanged — selectable via \`NETWORKPIPELINE_PROVIDER=anthropic\` for CI / automation / multi-user contexts.

## Test totals

| Workspace | Tests | Δ |
|---|---|---|
| criteria | 51 | — |
| db | 72 | — |
| evaluator | 119 | +7 |
| discovery | 103 | — |
| mcp-server | 25 | — |
| **Total** | **370** | **+7** |

All 5 workspaces typecheck clean; zero failures.

## Caveats

- MCP sampling does not surface per-call token counts or USD cost to the server. \`provider_runs.input_tokens / output_tokens / cache_*_tokens\` are 0 and \`cost_usd_cents\` is NULL when running through Claude Code. The eval-harness \`prompt_cache_hit_ratio\` and \`cost_per_evaluation\` metrics only have data in \`anthropic\` mode.
- No automated end-to-end sampling test (the unit tests use a mock delegate). A real round-trip would need a fake MCP client; useful follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)