### PR TITLE
Cost engineering: role_kind filter + max_results cap + extraction cache

### DIFF
--- a/apps/mcp-server/src/__tests__/discovery_tools.test.ts
+++ b/apps/mcp-server/src/__tests__/discovery_tools.test.ts
@@ -380,6 +380,8 @@ describe("run_saved_search — greenhouse direct path", () => {
         status: "queued",
         pre_filter_reason_code: null,
         job_evaluation_id: null,
+        cached_job_evaluation_id: null,
+        input_hash: null,
         discovered_at: "2026-04-29T10:00:00Z",
         last_seen_at: "2026-04-29T10:00:00Z"
       });
@@ -406,6 +408,151 @@ describe("run_saved_search — greenhouse direct path", () => {
 
       // Suppress unused-variable lint without affecting wire test.
       assert.equal(typeof fetchImpl, "function");
+    } finally {
+      conn.close();
+    }
+  });
+});
+
+describe("run_saved_search — max_results cap (manual_paste)", () => {
+  it("caps the number of evaluated postings at SavedSearch.max_results", async () => {
+    const conn = openDb({ path: ":memory:" });
+    try {
+      // 5 evaluator calls expected (cap of 5 over 50 URLs).
+      const provider = makeAcceptingProvider(5);
+      const runtime = makeRuntime(conn, provider);
+      const registry = buildRegistry(runtime);
+
+      // Create with 50 URLs but max_results=5.
+      const created = await registry.dispatch(
+        "create_saved_search",
+        {
+          label: "capped",
+          sources_json: JSON.stringify(["manual_paste"]),
+          queries_json: JSON.stringify([
+            {
+              source: "manual_paste",
+              urls: Array.from(
+                { length: 50 },
+                (_, i) => `https://example.com/job/${i}`
+              )
+            }
+          ]),
+          max_results: 5
+        },
+        { invocationId: "inv-create" }
+      );
+      assert.equal(created.ok, true);
+      if (!created.ok) return;
+      const ssId = (created.output as { id: string }).id;
+
+      const run = await registry.dispatch(
+        "run_saved_search",
+        { saved_search_id: ssId },
+        { invocationId: "inv-run" }
+      );
+      assert.equal(run.ok, true);
+      if (!run.ok) return;
+      const result = run.output as {
+        search_run_id: string;
+        digest: { evaluated: number };
+      };
+      // Cap: only 5 of the 50 URLs even reach evaluation.
+      assert.equal(result.digest.evaluated, 5);
+
+      const rows = runtime.repositories.discoveredPostings.listBySearchRun(
+        result.search_run_id
+      );
+      assert.equal(rows.length, 5);
+    } finally {
+      conn.close();
+    }
+  });
+});
+
+describe("run_saved_search — facts cache across criteria versions", () => {
+  it("second run with a different criteria version reuses cached facts (skips extract LLM call)", async () => {
+    const conn = openDb({ path: ":memory:" });
+    try {
+      // First run needs 1 extract response. Second run skips extract,
+      // values is empty → short-circuits, but we still need a soft-score
+      // response on each run since the runtime's default criteria has
+      // empty refusals & empty soft preferences. With empty soft prefs,
+      // softScore short-circuits too — so we expect ZERO provider calls
+      // on the second run. Provide exactly 1 response (for run 1's
+      // extract).
+      const provider = makeAcceptingProvider(1);
+      const runtime = makeRuntime(conn, provider);
+      const registry = buildRegistry(runtime);
+
+      // Create a saved_search with one URL.
+      const created = await registry.dispatch(
+        "create_saved_search",
+        {
+          label: "cache-test",
+          sources_json: JSON.stringify(["manual_paste"]),
+          queries_json: JSON.stringify([
+            {
+              source: "manual_paste",
+              urls: ["https://example.com/job/cache-1"]
+            }
+          ])
+        },
+        { invocationId: "inv-c" }
+      );
+      assert.equal(created.ok, true);
+      if (!created.ok) return;
+      const ssId = (created.output as { id: string }).id;
+
+      // Run 1 — extract LLM call happens.
+      const r1 = await registry.dispatch(
+        "run_saved_search",
+        { saved_search_id: ssId },
+        { invocationId: "inv-r1" }
+      );
+      assert.equal(r1.ok, true);
+      if (!r1.ok) return;
+      const out1 = r1.output as {
+        search_run_id: string;
+        digest: { evaluated: number };
+      };
+      assert.equal(out1.digest.evaluated, 1);
+
+      // Provider has consumed its single extract response. Second run
+      // must NOT need a new extract response — the cache reuses the
+      // facts persisted from run 1. We swap the criteriaVersionId to
+      // simulate "criteria changed since run 1".
+      runtime.criteriaVersionId = "different-version";
+
+      // Run 2 — same URL, different criteria version → reuse facts.
+      const r2 = await registry.dispatch(
+        "run_saved_search",
+        { saved_search_id: ssId },
+        { invocationId: "inv-r2" }
+      );
+      assert.equal(r2.ok, true);
+      if (!r2.ok) return;
+      const out2 = r2.output as {
+        search_run_id: string;
+        digest: { evaluated: number };
+      };
+      assert.equal(out2.digest.evaluated, 1);
+
+      // The second-run posting should have cached_job_evaluation_id set.
+      const rows = runtime.repositories.discoveredPostings.listBySearchRun(
+        out2.search_run_id
+      );
+      assert.equal(rows.length, 1);
+      assert.ok(
+        rows[0].cached_job_evaluation_id,
+        "cached_job_evaluation_id should be set"
+      );
+
+      // Confirm we created TWO job_evaluations (one per criteria_version_id).
+      const evals = runtime.repositories.jobEvaluations.listByCriteriaVersion(
+        runtime.criteriaVersionId
+      );
+      assert.equal(evals.length, 1);
     } finally {
       conn.close();
     }

--- a/apps/mcp-server/src/tools/create-saved-search.ts
+++ b/apps/mcp-server/src/tools/create-saved-search.ts
@@ -12,7 +12,13 @@ const inputSchema = z
     sources_json: z.string().min(1),
     queries_json: z.string().min(1),
     criteria_overlay_path: z.string().nullable().optional(),
-    cadence: cadenceSchema.optional()
+    cadence: cadenceSchema.optional(),
+    /**
+     * Optional per-search result cap. When set, connectors truncate
+     * their result list to at most this many postings. Default 50.
+     * Caps each search at $0.50 worth of LLM calls instead of $5+.
+     */
+    max_results: z.number().int().positive().max(500).optional()
   })
   .strict();
 
@@ -48,6 +54,7 @@ export function makeCreateSavedSearchTool(
         queries_json: input.queries_json,
         criteria_overlay_path: input.criteria_overlay_path ?? null,
         cadence: input.cadence ?? "on_demand",
+        max_results: input.max_results ?? null,
         created_at: now,
         updated_at: now,
         last_run_at: null

--- a/apps/mcp-server/src/tools/discover-jobs.ts
+++ b/apps/mcp-server/src/tools/discover-jobs.ts
@@ -50,7 +50,14 @@ const sourceQuerySchema: z.ZodType<SourceQuery> = z.union([
 const inputSchema = z
   .object({
     saved_search_id: z.string().min(1).optional(),
-    ad_hoc_queries: z.array(sourceQuerySchema).optional()
+    ad_hoc_queries: z.array(sourceQuerySchema).optional(),
+    /**
+     * Optional per-search cap. When omitted with a saved_search_id,
+     * inherits the SavedSearch.max_results column. When omitted on
+     * the ad-hoc path, falls back to connector-side
+     * DEFAULT_MAX_RESULTS (50).
+     */
+    max_results: z.number().int().positive().max(500).optional()
   })
   .strict()
   .refine(
@@ -71,6 +78,7 @@ export type DiscoverJobsOutput = {
     inserted: number;
     pre_filter_rejected: number;
     duplicates_skipped: number;
+    cached_facts_reused: number;
     passed_to_eval: number;
     ready_for_eval_ids: string[];
   };
@@ -104,21 +112,26 @@ export function makeDiscoverJobsTool(
       "Kick off a search run by either a saved_search_id or ad-hoc queries. Returns direct-fetch results and any Claude-executed instructions for instruction-based sources (Indeed, recruiter_email, career_page).",
     inputSchema,
     handler: async (input) => {
-      const { savedSearchId, queries } = resolveQueries(runtime, input);
+      const { savedSearchId, queries, maxResults } = resolveQueries(
+        runtime,
+        input
+      );
       const runId = randomUUID();
 
       const start = await startDiscovery(runtime.repositories, {
         savedSearchId,
         runId,
         queries,
-        connectorById
+        connectorById,
+        maxResults
       });
 
       const recorded = recordDiscoveredPostings(runtime.repositories, {
         savedSearchId,
         runId,
         postings: start.direct_postings,
-        criteria: runtime.criteria
+        criteria: runtime.criteria,
+        criteriaVersionId: runtime.criteriaVersionId
       });
 
       return {
@@ -127,6 +140,7 @@ export function makeDiscoverJobsTool(
           inserted: recorded.inserted_postings,
           pre_filter_rejected: recorded.pre_filter_rejected,
           duplicates_skipped: recorded.duplicates_skipped,
+          cached_facts_reused: recorded.cached_facts_reused,
           passed_to_eval: recorded.passed_to_eval,
           ready_for_eval_ids: recorded.ready_for_eval_ids
         },
@@ -152,7 +166,11 @@ export function makeDiscoverJobsTool(
 function resolveQueries(
   runtime: Runtime,
   input: Input
-): { savedSearchId: string; queries: SourceQuery[] } {
+): {
+  savedSearchId: string;
+  queries: SourceQuery[];
+  maxResults: number | undefined;
+} {
   if (input.saved_search_id) {
     const row = runtime.repositories.savedSearches.findById(
       input.saved_search_id
@@ -170,11 +188,14 @@ function resolveQueries(
         }`
       );
     }
-    return { savedSearchId: row.id, queries };
+    // Explicit input override > SavedSearch.max_results > undefined.
+    const maxResults = input.max_results ?? row.max_results ?? undefined;
+    return { savedSearchId: row.id, queries, maxResults };
   }
   // Ad-hoc — synthesize a parent id to keep FK shape clean.
   return {
     savedSearchId: `ad_hoc:${randomUUID()}`,
-    queries: input.ad_hoc_queries ?? []
+    queries: input.ad_hoc_queries ?? [],
+    maxResults: input.max_results
   };
 }

--- a/apps/mcp-server/src/tools/record-discovered-postings.ts
+++ b/apps/mcp-server/src/tools/record-discovered-postings.ts
@@ -36,6 +36,7 @@ export type RecordDiscoveredPostingsOutput = {
   inserted_postings: number;
   pre_filter_rejected: number;
   duplicates_skipped: number;
+  cached_facts_reused: number;
   passed_to_eval: number;
   ready_for_eval_ids: string[];
 };
@@ -86,12 +87,20 @@ export function makeRecordDiscoveredPostingsTool(
         );
       }
 
-      const postings = connector.recordResults(input.payload);
+      // Look up SavedSearch.max_results so the connector enforces the
+      // cap on its side too (defense in depth — Claude may have
+      // ignored the discoverInstruction's `limit` arg and overshot).
+      const ss = runtime.repositories.savedSearches.findById(
+        run.saved_search_id
+      );
+      const maxResults = ss?.max_results ?? undefined;
+      const postings = connector.recordResults(input.payload, maxResults);
       const recorded = recordDiscoveredPostings(runtime.repositories, {
         savedSearchId: run.saved_search_id,
         runId: run.id,
         postings,
-        criteria: runtime.criteria
+        criteria: runtime.criteria,
+        criteriaVersionId: runtime.criteriaVersionId
       });
 
       return {
@@ -99,6 +108,7 @@ export function makeRecordDiscoveredPostingsTool(
         inserted_postings: recorded.inserted_postings,
         pre_filter_rejected: recorded.pre_filter_rejected,
         duplicates_skipped: recorded.duplicates_skipped,
+        cached_facts_reused: recorded.cached_facts_reused,
         passed_to_eval: recorded.passed_to_eval,
         ready_for_eval_ids: recorded.ready_for_eval_ids
       };

--- a/apps/mcp-server/src/tools/run-saved-search.ts
+++ b/apps/mcp-server/src/tools/run-saved-search.ts
@@ -77,20 +77,25 @@ export function makeRunSavedSearchTool(
 
       const runId = randomUUID();
 
-      // Fan out.
+      // Fan out. Pass through the saved search's max_results cap when
+      // present; connectors fall back to DEFAULT_MAX_RESULTS otherwise.
       const start = await startDiscovery(runtime.repositories, {
         savedSearchId: ss.id,
         runId,
         queries,
-        connectorById
+        connectorById,
+        maxResults: ss.max_results ?? undefined
       });
 
-      // Persist + pre-filter direct results.
+      // Persist + pre-filter direct results. Pass criteriaVersionId
+      // so the cache lookup can distinguish "same-criteria duplicate"
+      // (skip eval entirely) from "different-criteria, reuse facts".
       const recorded = recordDiscoveredPostings(runtime.repositories, {
         savedSearchId: ss.id,
         runId,
         postings: start.direct_postings,
-        criteria: runtime.criteria
+        criteria: runtime.criteria,
+        criteriaVersionId: runtime.criteriaVersionId
       });
 
       // Evaluate the direct survivors immediately.

--- a/packages/criteria/src/index.ts
+++ b/packages/criteria/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  ALL_ROLE_KINDS,
   CURRENT_SCHEMA_VERSION,
   acceptedCalibrationExampleSchema,
   calibrationSchema,
@@ -10,6 +11,7 @@ export {
   mustNotHaveConditionSchema,
   profileSchema,
   rejectedCalibrationExampleSchema,
+  roleKindSchema,
   seniorityBandSchema,
   softPreferenceItemSchema,
   softPreferencesSchema,
@@ -28,6 +30,7 @@ export type {
   MustNotHaveCondition,
   Profile,
   RejectedCalibrationExample,
+  RoleKind,
   SeniorityBand,
   SoftPreferenceItem,
   SoftPreferences,

--- a/packages/criteria/src/schema.ts
+++ b/packages/criteria/src/schema.ts
@@ -17,6 +17,69 @@ export const seniorityBandSchema = z.enum([
 ]);
 export type SeniorityBand = z.infer<typeof seniorityBandSchema>;
 
+/**
+ * Coarse role-kind taxonomy used by the deterministic title-classifier
+ * pre-extraction filter (see packages/discovery/src/connector/role_kind.ts).
+ *
+ * Lives in @networkpipeline/criteria — alongside SeniorityBand — so both
+ * `discovery` (for inference) and `evaluator` (for gating) can import it
+ * without forcing a `discovery → evaluator → discovery` cycle.
+ *
+ * Multi-tag is intentional: a "Solutions Engineer" is both `engineering`
+ * and `sales`. The user's blocklist controls which tags reject; the
+ * classifier may emit several.
+ *
+ * `"other"` means "title didn't match any kind". Pre-extraction treats
+ * an `["other"]` (or empty) result as a defer, NOT a reject — same
+ * defer-on-ambiguity contract as role_seniority.
+ */
+export const roleKindSchema = z.enum([
+  "engineering",
+  "research",
+  "ml",
+  "infrastructure",
+  "security",
+  "design",
+  "product",
+  "sales",
+  "customer_success",
+  "marketing",
+  "recruiting",
+  "people_ops",
+  "finance",
+  "legal",
+  "operations",
+  "support",
+  "data",
+  "devrel",
+  "policy",
+  "other"
+]);
+export type RoleKind = z.infer<typeof roleKindSchema>;
+
+export const ALL_ROLE_KINDS: readonly RoleKind[] = [
+  "engineering",
+  "research",
+  "ml",
+  "infrastructure",
+  "security",
+  "design",
+  "product",
+  "sales",
+  "customer_success",
+  "marketing",
+  "recruiting",
+  "people_ops",
+  "finance",
+  "legal",
+  "operations",
+  "support",
+  "data",
+  "devrel",
+  "policy",
+  "other"
+] as const;
+
 export const workAuthorizationSchema = z.enum([
   "us_citizen",
   "us_citizen_or_permanent_resident",
@@ -108,12 +171,19 @@ const mustNotHaveLocationRequirement = z.object({
   reason: z.string().min(1)
 });
 
+const mustNotHaveRoleKind = z.object({
+  kind: z.literal("role_kind"),
+  any_of: z.array(roleKindSchema).min(1),
+  reason: z.string().min(1)
+});
+
 export const mustNotHaveConditionSchema = z.discriminatedUnion("kind", [
   mustNotHaveRequiredClearance,
   mustNotHaveIndustry,
   mustNotHaveCompany,
   mustNotHaveRoleSeniority,
-  mustNotHaveLocationRequirement
+  mustNotHaveLocationRequirement,
+  mustNotHaveRoleKind
 ]);
 export type MustNotHaveCondition = z.infer<typeof mustNotHaveConditionSchema>;
 

--- a/packages/db/src/__tests__/discovered_postings.test.ts
+++ b/packages/db/src/__tests__/discovered_postings.test.ts
@@ -20,6 +20,8 @@ function basePosting(
     status: "queued",
     pre_filter_reason_code: null,
     job_evaluation_id: null,
+    cached_job_evaluation_id: null,
+    input_hash: null,
     discovered_at: "2026-01-01T00:00:00Z",
     last_seen_at: "2026-01-01T00:00:00Z",
     ...overrides

--- a/packages/db/src/__tests__/saved_searches.test.ts
+++ b/packages/db/src/__tests__/saved_searches.test.ts
@@ -17,6 +17,7 @@ function baseSearch(
     ]),
     criteria_overlay_path: null,
     cadence: "on_demand",
+    max_results: null,
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
     last_run_at: null,
@@ -39,6 +40,26 @@ describe("SavedSearchesRepository — basic CRUD", () => {
     // JSON round-trip preserved
     const sources = JSON.parse(out!.sources_json) as string[];
     assert.deepEqual(sources, ["indeed", "greenhouse"]);
+  });
+
+  it("round-trips max_results when set", () => {
+    repo.insert(
+      baseSearch({
+        id: "ss-cap",
+        label: "with cap",
+        max_results: 25
+      })
+    );
+    const out = repo.findById("ss-cap");
+    assert.equal(out?.max_results, 25);
+  });
+
+  it("max_results defaults to null when omitted", () => {
+    repo.insert(
+      baseSearch({ id: "ss-uncap", label: "no cap", max_results: null })
+    );
+    const out = repo.findById("ss-uncap");
+    assert.equal(out?.max_results, null);
   });
 
   it("preserves criteria_overlay_path when set", () => {

--- a/packages/db/src/connection.ts
+++ b/packages/db/src/connection.ts
@@ -2,7 +2,10 @@ import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { APPLY_SCHEMA_DDL } from "./schema/index.js";
+import {
+  ADDITIVE_COLUMN_MIGRATIONS,
+  APPLY_SCHEMA_DDL
+} from "./schema/index.js";
 
 /**
  * AppDatabase is the typed wrapper around node:sqlite's DatabaseSync.
@@ -81,9 +84,14 @@ export function openDb(options: OpenDbOptions = {}): Connection {
 }
 
 /**
- * Apply every DDL statement from `APPLY_SCHEMA_DDL`. Each statement is
- * idempotent (CREATE TABLE/INDEX IF NOT EXISTS), so this can be called
- * repeatedly without harm.
+ * Apply every DDL statement from `APPLY_SCHEMA_DDL`, then attempt
+ * `ADDITIVE_COLUMN_MIGRATIONS` (each wrapped in a try/catch since
+ * SQLite has no `IF NOT EXISTS` on ALTER TABLE).
+ *
+ * The CREATE TABLE block is idempotent. The ALTER block is
+ * idempotent-with-errors: when a column already exists, SQLite throws
+ * "duplicate column name"; we recognize that case and swallow it.
+ * Anything else (a real schema bug) bubbles up.
  */
 export function applySchema(db: AppDatabase): void {
   db.exec("BEGIN");
@@ -95,6 +103,20 @@ export function applySchema(db: AppDatabase): void {
   } catch (err) {
     db.exec("ROLLBACK");
     throw err;
+  }
+  // Migrations run OUTSIDE the transaction so a failed ALTER doesn't
+  // roll back the CREATE TABLEs. Each migration is independent.
+  for (const stmt of ADDITIVE_COLUMN_MIGRATIONS) {
+    try {
+      db.exec(stmt);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (/duplicate column name/i.test(msg)) {
+        // Column already exists from a prior boot or fresh CREATE TABLE.
+        continue;
+      }
+      throw err;
+    }
   }
 }
 

--- a/packages/db/src/repositories/discovered_postings.ts
+++ b/packages/db/src/repositories/discovered_postings.ts
@@ -11,6 +11,15 @@ export type UpdateStatusOpts = {
   jobEvaluationId?: string;
 };
 
+export type FindByInputHashOpts = {
+  /**
+   * When set, restricts results to rows whose linked job_evaluation
+   * matches this extractor_version. Used by the cache lookup to
+   * ensure facts_json was produced by a compatible extractor.
+   */
+  extractorVersion?: string;
+};
+
 const ALL_STATUSES: readonly DiscoveredPostingStatus[] = [
   "queued",
   "pre_filter_rejected",
@@ -24,8 +33,9 @@ INSERT INTO discovered_postings (
   id, saved_search_id, search_run_id, source, external_ref, url,
   title, company, raw_metadata_json, status,
   pre_filter_reason_code, job_evaluation_id,
+  cached_job_evaluation_id, input_hash,
   discovered_at, last_seen_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `;
 
 const FIND_BY_ID_SQL = `SELECT * FROM discovered_postings WHERE id = ?`;
@@ -66,6 +76,9 @@ WHERE id = ?
 const TOUCH_LAST_SEEN_SQL = `
 UPDATE discovered_postings SET last_seen_at = ? WHERE id = ?
 `;
+const SET_CACHED_JOB_EVAL_SQL = `
+UPDATE discovered_postings SET cached_job_evaluation_id = ? WHERE id = ?
+`;
 const COUNT_BY_STATUS_FOR_RUN_SQL = `
 SELECT status, COUNT(*) AS n
 FROM discovered_postings
@@ -83,6 +96,7 @@ export class DiscoveredPostingsRepository {
   private readonly listByStatusStmt: ReturnType<AppDatabase["prepare"]>;
   private readonly updateStatusStmt: ReturnType<AppDatabase["prepare"]>;
   private readonly touchLastSeenStmt: ReturnType<AppDatabase["prepare"]>;
+  private readonly setCachedJobEvalStmt: ReturnType<AppDatabase["prepare"]>;
   private readonly countByStatusForRunStmt: ReturnType<AppDatabase["prepare"]>;
 
   constructor(private readonly db: AppDatabase) {
@@ -95,6 +109,7 @@ export class DiscoveredPostingsRepository {
     this.listByStatusStmt = db.prepare(LIST_BY_STATUS_SQL);
     this.updateStatusStmt = db.prepare(UPDATE_STATUS_SQL);
     this.touchLastSeenStmt = db.prepare(TOUCH_LAST_SEEN_SQL);
+    this.setCachedJobEvalStmt = db.prepare(SET_CACHED_JOB_EVAL_SQL);
     this.countByStatusForRunStmt = db.prepare(COUNT_BY_STATUS_FOR_RUN_SQL);
   }
 
@@ -112,6 +127,8 @@ export class DiscoveredPostingsRepository {
       row.status,
       row.pre_filter_reason_code,
       row.job_evaluation_id,
+      row.cached_job_evaluation_id,
+      row.input_hash,
       row.discovered_at,
       row.last_seen_at
     );
@@ -203,6 +220,16 @@ export class DiscoveredPostingsRepository {
    */
   touchLastSeen(id: string, isoTimestamp: string): void {
     this.touchLastSeenStmt.run(isoTimestamp, id);
+  }
+
+  /**
+   * Set the `cached_job_evaluation_id` FK on a row. Used by the
+   * orchestrator's three-branch dedup logic when a prior evaluation's
+   * `facts_json` is reusable across criteria versions. The evaluator
+   * loop reads this column to skip the extract LLM call.
+   */
+  setCachedJobEvaluationId(id: string, jobEvaluationId: string): void {
+    this.setCachedJobEvalStmt.run(jobEvaluationId, id);
   }
 
   /**

--- a/packages/db/src/repositories/job_evaluations.ts
+++ b/packages/db/src/repositories/job_evaluations.ts
@@ -42,6 +42,11 @@ SELECT * FROM job_evaluations
 WHERE input_hash = ? AND extractor_version = ? AND criteria_version_id = ?
 ORDER BY created_at DESC LIMIT 1
 `;
+const FIND_BY_INPUT_HASH_SQL = `
+SELECT * FROM job_evaluations
+WHERE input_hash = ? AND extractor_version = ?
+ORDER BY created_at DESC LIMIT 1
+`;
 
 export class JobEvaluationsRepository {
   private readonly insertStmt: ReturnType<AppDatabase["prepare"]>;
@@ -51,6 +56,7 @@ export class JobEvaluationsRepository {
   private readonly countByVerdictStmt: ReturnType<AppDatabase["prepare"]>;
   private readonly dedupNullStmt: ReturnType<AppDatabase["prepare"]>;
   private readonly dedupWithStmt: ReturnType<AppDatabase["prepare"]>;
+  private readonly findByInputHashStmt: ReturnType<AppDatabase["prepare"]>;
 
   constructor(private readonly db: AppDatabase) {
     this.insertStmt = db.prepare(INSERT_SQL);
@@ -60,6 +66,7 @@ export class JobEvaluationsRepository {
     this.countByVerdictStmt = db.prepare(COUNT_BY_VERDICT_SQL);
     this.dedupNullStmt = db.prepare(DEDUP_NULL_CV_SQL);
     this.dedupWithStmt = db.prepare(DEDUP_WITH_CV_SQL);
+    this.findByInputHashStmt = db.prepare(FIND_BY_INPUT_HASH_SQL);
   }
 
   insert(row: JobEvaluationInsert): void {
@@ -107,6 +114,25 @@ export class JobEvaluationsRepository {
       key.extractor_version,
       key.criteria_version_id
     ) as JobEvaluationRow | undefined;
+  }
+
+  /**
+   * Cache lookup ignoring criteria_version_id. Returns the most-recent
+   * job_evaluation whose `(input_hash, extractor_version)` matches the
+   * supplied pair, regardless of which criteria version produced it.
+   *
+   * Used by the orchestrator's three-branch dedup logic to reuse
+   * `facts_json` across criteria versions — same posting, same
+   * extractor, different criteria. The caller still persists a fresh
+   * job_evaluations row scoped to the CURRENT criteria_version_id.
+   */
+  findByInputHash(
+    inputHash: string,
+    extractorVersion: string
+  ): JobEvaluationRow | undefined {
+    return this.findByInputHashStmt.get(inputHash, extractorVersion) as
+      | JobEvaluationRow
+      | undefined;
   }
 
   listByVerdict(verdict: Verdict, limit = 50): JobEvaluationRow[] {

--- a/packages/db/src/repositories/saved_searches.ts
+++ b/packages/db/src/repositories/saved_searches.ts
@@ -7,8 +7,8 @@ import type {
 const INSERT_SQL = `
 INSERT INTO saved_searches (
   id, label, sources_json, queries_json, criteria_overlay_path,
-  cadence, created_at, updated_at, last_run_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  cadence, max_results, created_at, updated_at, last_run_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `;
 
 const FIND_BY_ID_SQL = `SELECT * FROM saved_searches WHERE id = ?`;
@@ -51,6 +51,7 @@ export class SavedSearchesRepository {
       row.queries_json,
       row.criteria_overlay_path,
       row.cadence,
+      row.max_results,
       row.created_at,
       row.updated_at,
       row.last_run_at

--- a/packages/db/src/schema/discovered_postings.ts
+++ b/packages/db/src/schema/discovered_postings.ts
@@ -59,6 +59,20 @@ export type DiscoveredPostingRow = {
   pre_filter_reason_code: string | null;
   /** FK to job_evaluations.id, non-null when status="evaluated". */
   job_evaluation_id: string | null;
+  /**
+   * FK to a PRIOR job_evaluations.id whose `facts_json` can be reused
+   * (same posting body, same extractor_version, DIFFERENT criteria
+   * version). When set, the evaluator skips the extract LLM call and
+   * runs gates+values+score against the current criteria, persisting
+   * a fresh job_evaluations row scoped to the new criteria_version_id.
+   */
+  cached_job_evaluation_id: string | null;
+  /**
+   * SHA-256 of (title + company + first 2KB of description) — see
+   * `computePostingInputHash`. Used to look up cached evaluations
+   * across criteria versions.
+   */
+  input_hash: string | null;
   /** ISO-8601. */
   discovered_at: string;
   /** ISO-8601, updated when the same posting reappears in a later run. */

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -132,6 +132,7 @@ export const APPLY_SCHEMA_DDL = [
     queries_json TEXT NOT NULL,
     criteria_overlay_path TEXT,
     cadence TEXT NOT NULL,
+    max_results INTEGER,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     last_run_at TEXT
@@ -174,6 +175,8 @@ export const APPLY_SCHEMA_DDL = [
     status TEXT NOT NULL,
     pre_filter_reason_code TEXT,
     job_evaluation_id TEXT,
+    cached_job_evaluation_id TEXT,
+    input_hash TEXT,
     discovered_at TEXT NOT NULL,
     last_seen_at TEXT NOT NULL
   )`,
@@ -182,5 +185,22 @@ export const APPLY_SCHEMA_DDL = [
   `CREATE INDEX IF NOT EXISTS idx_discovered_postings_status ON discovered_postings(status)`,
   `CREATE INDEX IF NOT EXISTS idx_discovered_postings_source ON discovered_postings(source)`,
   `CREATE INDEX IF NOT EXISTS idx_discovered_postings_url ON discovered_postings(url)`,
-  `CREATE INDEX IF NOT EXISTS idx_discovered_postings_external_ref ON discovered_postings(source, external_ref)`
+  `CREATE INDEX IF NOT EXISTS idx_discovered_postings_external_ref ON discovered_postings(source, external_ref)`,
+  `CREATE INDEX IF NOT EXISTS idx_discovered_postings_input_hash ON discovered_postings(input_hash)`
+] as const;
+
+/**
+ * Additive column migrations applied AFTER `APPLY_SCHEMA_DDL`. SQLite
+ * doesn't support `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`, so each
+ * statement is wrapped in a per-statement try/catch in `applySchema`
+ * — duplicate-column errors are swallowed; everything else propagates.
+ *
+ * Pattern: when adding a new nullable column to an existing table, add
+ * the column to the CREATE TABLE block above (so fresh DBs get it) AND
+ * append the matching ALTER here (so existing on-disk DBs pick it up).
+ */
+export const ADDITIVE_COLUMN_MIGRATIONS = [
+  `ALTER TABLE saved_searches ADD COLUMN max_results INTEGER`,
+  `ALTER TABLE discovered_postings ADD COLUMN cached_job_evaluation_id TEXT`,
+  `ALTER TABLE discovered_postings ADD COLUMN input_hash TEXT`
 ] as const;

--- a/packages/db/src/schema/saved_searches.ts
+++ b/packages/db/src/schema/saved_searches.ts
@@ -36,6 +36,13 @@ export type SavedSearchRow = {
   /** Optional relative path or template id for a criteria overlay. */
   criteria_overlay_path: string | null;
   cadence: Cadence;
+  /**
+   * Optional per-search result cap. When non-null, each connector
+   * truncates its result list to at most this many postings (default
+   * 50, max 500). Drives the cost-engineering "don't burn 30 minutes
+   * on a 443-posting board" gate.
+   */
+  max_results: number | null;
   /** ISO-8601. */
   created_at: string;
   /** ISO-8601. */

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "typecheck": "tsc --project tsconfig.json --noEmit",
-    "test": "node --import tsx --test src/__tests__/seniority.test.ts src/__tests__/html.test.ts src/__tests__/dedup.test.ts src/__tests__/indeed.test.ts src/__tests__/greenhouse.test.ts src/__tests__/lever.test.ts src/__tests__/ashby.test.ts src/__tests__/career_page.test.ts src/__tests__/recruiter_email.test.ts src/__tests__/manual_paste.test.ts src/__tests__/registry.test.ts src/__tests__/orchestrator.test.ts"
+    "test": "node --import tsx --test src/__tests__/seniority.test.ts src/__tests__/role_kind.test.ts src/__tests__/html.test.ts src/__tests__/dedup.test.ts src/__tests__/indeed.test.ts src/__tests__/greenhouse.test.ts src/__tests__/lever.test.ts src/__tests__/ashby.test.ts src/__tests__/career_page.test.ts src/__tests__/recruiter_email.test.ts src/__tests__/manual_paste.test.ts src/__tests__/registry.test.ts src/__tests__/orchestrator.test.ts"
   },
   "dependencies": {
     "@networkpipeline/criteria": "0.1.0",

--- a/packages/discovery/src/__tests__/dedup.test.ts
+++ b/packages/discovery/src/__tests__/dedup.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { canonicalizeUrl } from "../dedup.js";
+import { canonicalizeUrl, computePostingInputHash } from "../dedup.js";
+import type { NormalizedDiscoveredPosting } from "../connector/types.js";
 
 describe("canonicalizeUrl", () => {
   it("lowercases the host", () => {
@@ -65,5 +66,66 @@ describe("canonicalizeUrl", () => {
       canonicalizeUrl(input),
       "https://jobs.lever.co/Acme/abc-123?id=7"
     );
+  });
+});
+
+function basePosting(
+  overrides: Partial<NormalizedDiscoveredPosting> = {}
+): NormalizedDiscoveredPosting {
+  return {
+    source: "greenhouse",
+    external_ref: "x",
+    url: "https://example.com/x",
+    title: "Software Engineer",
+    company: "Acme",
+    description_excerpt: "Build cool things.",
+    onsite_locations: [],
+    is_onsite_required: null,
+    employment_type: null,
+    inferred_seniority_signals: [],
+    inferred_role_kinds: ["engineering"],
+    raw_metadata: {},
+    ...overrides
+  };
+}
+
+describe("computePostingInputHash", () => {
+  it("produces a stable hash for identical postings", () => {
+    const a = computePostingInputHash(basePosting());
+    const b = computePostingInputHash(basePosting());
+    assert.equal(a, b);
+    assert.equal(a.length, 64); // SHA-256 hex
+  });
+
+  it("differs when title changes", () => {
+    const a = computePostingInputHash(basePosting({ title: "A" }));
+    const b = computePostingInputHash(basePosting({ title: "B" }));
+    assert.notEqual(a, b);
+  });
+
+  it("differs when company changes", () => {
+    const a = computePostingInputHash(basePosting({ company: "Acme" }));
+    const b = computePostingInputHash(basePosting({ company: "Beta" }));
+    assert.notEqual(a, b);
+  });
+
+  it("ignores trailing whitespace and case in title/company", () => {
+    const a = computePostingInputHash(
+      basePosting({ title: "Software Engineer", company: "Acme" })
+    );
+    const b = computePostingInputHash(
+      basePosting({ title: "  software engineer  ", company: "ACME" })
+    );
+    assert.equal(a, b);
+  });
+
+  it("treats null vs empty description_excerpt as equal", () => {
+    const a = computePostingInputHash(
+      basePosting({ description_excerpt: null })
+    );
+    const b = computePostingInputHash(
+      basePosting({ description_excerpt: "" })
+    );
+    assert.equal(a, b);
   });
 });

--- a/packages/discovery/src/__tests__/greenhouse.test.ts
+++ b/packages/discovery/src/__tests__/greenhouse.test.ts
@@ -172,6 +172,48 @@ describe("greenhouseConnector", () => {
     assert.equal(result.errors.length, 1);
   });
 
+  it("respects maxResults cap by truncating after mapping", async () => {
+    // Mock returns 100 jobs; max_results=10 → 10 returned.
+    const manyJobs = Array.from({ length: 100 }, (_, i) => ({
+      id: i + 1,
+      title: `Software Engineer ${i + 1}`,
+      content: "<p>Build things.</p>",
+      absolute_url: `https://boards-api.greenhouse.io/acme/jobs/${i + 1}`,
+      location: { name: "Remote" },
+      offices: [{ location: "Remote" }],
+      metadata: []
+    }));
+    const stub = mockFetch({ json: { jobs: manyJobs } });
+    const c = greenhouseConnector({ fetchImpl: stub });
+    const result = await c.discoverDirect(
+      { source: "greenhouse", company_slug: "acme" },
+      10
+    );
+    assert.equal(result.postings.length, 10);
+    // Truncation preserves source order — first 10 jobs should remain.
+    assert.equal(result.postings[0].external_ref, "1");
+    assert.equal(result.postings[9].external_ref, "10");
+  });
+
+  it("falls back to DEFAULT_MAX_RESULTS (50) when no cap supplied", async () => {
+    const manyJobs = Array.from({ length: 100 }, (_, i) => ({
+      id: i + 1,
+      title: `Software Engineer ${i + 1}`,
+      content: "<p>x</p>",
+      absolute_url: `https://example.com/${i + 1}`,
+      location: { name: "Remote" },
+      offices: [{ location: "Remote" }],
+      metadata: []
+    }));
+    const stub = mockFetch({ json: { jobs: manyJobs } });
+    const c = greenhouseConnector({ fetchImpl: stub });
+    const result = await c.discoverDirect({
+      source: "greenhouse",
+      company_slug: "acme"
+    });
+    assert.equal(result.postings.length, 50);
+  });
+
   it("constructs the correct URL", async () => {
     let capturedUrl = "";
     const stub: FetchImpl = (async (input: unknown) => {

--- a/packages/discovery/src/__tests__/indeed.test.ts
+++ b/packages/discovery/src/__tests__/indeed.test.ts
@@ -25,7 +25,7 @@ describe("indeedConnector", () => {
     assert.equal(wi.tool, "mcp__claude_ai_Indeed__search_jobs");
     assert.equal(wi.args.query, "ML engineer");
     assert.equal(wi.args.location, "Remote");
-    assert.equal(wi.args.limit, 25);
+    assert.equal(wi.args.limit, 50);
   });
 
   it("omits location arg when not provided", () => {
@@ -39,15 +39,43 @@ describe("indeedConnector", () => {
     assert.equal("location" in wi.args, false);
   });
 
-  it("respects custom limit", () => {
-    const c = indeedConnector({ limit: 50 });
+  it("respects factory-default limit", () => {
+    const c = indeedConnector({ limit: 100 });
     const inst = c.discoverInstruction(
       { source: "indeed", query: "x" },
       "run-1"
     );
     const wi = inst.work_items[0];
     if (wi.kind !== "claude_mcp_tool") throw new Error("unreachable");
-    assert.equal(wi.args.limit, 50);
+    assert.equal(wi.args.limit, 100);
+  });
+
+  it("per-call maxResults arg overrides the factory limit", () => {
+    const c = indeedConnector({ limit: 100 });
+    const inst = c.discoverInstruction(
+      { source: "indeed", query: "x" },
+      "run-1",
+      10 // SavedSearch.max_results=10 forwarded
+    );
+    const wi = inst.work_items[0];
+    if (wi.kind !== "claude_mcp_tool") throw new Error("unreachable");
+    assert.equal(wi.args.limit, 10);
+  });
+
+  it("recordResults truncates payload to maxResults", () => {
+    const c = indeedConnector();
+    const payload = {
+      jobs: Array.from({ length: 30 }, (_, i) => ({
+        job_id: `j-${i}`,
+        title: "Software Engineer",
+        company_name: "Co",
+        url: `https://example.com/j/${i}`
+      }))
+    };
+    const out = c.recordResults(payload, 5);
+    assert.equal(out.length, 5);
+    assert.equal(out[0].external_ref, "j-0");
+    assert.equal(out[4].external_ref, "j-4");
   });
 
   it("throws when query.source is wrong", () => {

--- a/packages/discovery/src/__tests__/orchestrator.test.ts
+++ b/packages/discovery/src/__tests__/orchestrator.test.ts
@@ -83,6 +83,7 @@ function seedSavedSearch(
       ]),
     criteria_overlay_path: null,
     cadence: "on_demand",
+    max_results: null,
     created_at: "2026-04-29T00:00:00Z",
     updated_at: "2026-04-29T00:00:00Z",
     last_run_at: null
@@ -200,6 +201,7 @@ describe("recordDiscoveredPostings", () => {
             is_onsite_required: null,
             employment_type: null,
             inferred_seniority_signals: [],
+            inferred_role_kinds: ["other"],
             raw_metadata: { url: "https://example.com/a" }
           }
         ],
@@ -267,6 +269,7 @@ describe("recordDiscoveredPostings", () => {
             is_onsite_required: null,
             employment_type: null,
             inferred_seniority_signals: [],
+            inferred_role_kinds: ["other"],
             raw_metadata: {}
           }
         ],
@@ -290,7 +293,7 @@ describe("recordDiscoveredPostings", () => {
     }
   });
 
-  it("dedupes by (source, external_ref) and links prior job_evaluation_id", async () => {
+  it("dedupes by input_hash + criteria_version_id and links prior job_evaluation_id", async () => {
     const conn = openDb({ path: ":memory:" });
     try {
       const repos = makeRepos(conn);
@@ -315,6 +318,7 @@ describe("recordDiscoveredPostings", () => {
         is_onsite_required: null,
         employment_type: null,
         inferred_seniority_signals: [],
+        inferred_role_kinds: ["other" as const],
         raw_metadata: {}
       };
 
@@ -322,17 +326,21 @@ describe("recordDiscoveredPostings", () => {
         savedSearchId: ssId,
         runId: runId1,
         criteria: baseCriteria(),
+        criteriaVersionId: "cv-1",
         postings: [posting],
         now: FIXED_NOW
       });
-      // Manually link first run's row to a synthetic eval id so we can
-      // assert the duplicate-link behavior.
+      // Manually link first run's row to a synthetic eval id with the
+      // same input_hash + criteria_version_id so the second run hits
+      // the "same-criteria, terminal verdict" branch.
       const firstId = r1.ready_for_eval_ids[0];
+      const firstRow = repos.discoveredPostings.findById(firstId);
+      const inputHash = firstRow!.input_hash!;
       const evalId = randomUUID();
       repos.jobEvaluations.insert({
         id: evalId,
-        input_hash: "hash",
-        criteria_version_id: null,
+        input_hash: inputHash,
+        criteria_version_id: "cv-1",
         extractor_version: "extract_v1",
         verdict: "accepted",
         reason_code: "",
@@ -362,16 +370,119 @@ describe("recordDiscoveredPostings", () => {
         savedSearchId: ssId,
         runId: runId2,
         criteria: baseCriteria(),
+        criteriaVersionId: "cv-1", // SAME criteria version → duplicate skip
         postings: [posting],
         now: FIXED_NOW
       });
       assert.equal(r2.duplicates_skipped, 1);
       assert.equal(r2.passed_to_eval, 0);
+      assert.equal(r2.cached_facts_reused, 0);
 
       const dupRows = repos.discoveredPostings.listBySearchRun(runId2);
       assert.equal(dupRows.length, 1);
       assert.equal(dupRows[0].status, "duplicate");
       assert.equal(dupRows[0].job_evaluation_id, evalId);
+    } finally {
+      conn.close();
+    }
+  });
+
+  it("reuses cached facts when input_hash matches a DIFFERENT criteria version", async () => {
+    const conn = openDb({ path: ":memory:" });
+    try {
+      const repos = makeRepos(conn);
+      const ssId = seedSavedSearch(conn);
+      const runId1 = randomUUID();
+      await startDiscovery(repos, {
+        savedSearchId: ssId,
+        runId: runId1,
+        queries: [],
+        connectorById: () => undefined,
+        now: FIXED_NOW
+      });
+
+      const posting = {
+        source: "greenhouse" as const,
+        external_ref: "gh-7",
+        url: "https://example.com/j/7",
+        title: "Software Engineer",
+        company: "Example",
+        description_excerpt: "Build cool things.",
+        onsite_locations: [],
+        is_onsite_required: null,
+        employment_type: null,
+        inferred_seniority_signals: [],
+        inferred_role_kinds: ["engineering" as const],
+        raw_metadata: {}
+      };
+
+      const r1 = recordDiscoveredPostings(repos, {
+        savedSearchId: ssId,
+        runId: runId1,
+        criteria: baseCriteria(),
+        criteriaVersionId: "cv-1",
+        postings: [posting],
+        now: FIXED_NOW
+      });
+      const firstId = r1.ready_for_eval_ids[0];
+      const inputHash = repos.discoveredPostings.findById(firstId)!.input_hash!;
+      const evalId = randomUUID();
+      repos.jobEvaluations.insert({
+        id: evalId,
+        input_hash: inputHash,
+        criteria_version_id: "cv-1",
+        extractor_version: "extract_v1",
+        verdict: "accepted",
+        reason_code: "",
+        short_circuited_at_stage: null,
+        stages_run_json: "[]",
+        facts_json: JSON.stringify({
+          extractor_version: "extract_v1",
+          title: "Software Engineer",
+          company: "Example",
+          seniority_signals: [],
+          required_clearance: null,
+          required_yoe: { min: null, max: null },
+          industry_tags: [],
+          required_onsite: { is_required: false, locations: [] },
+          employment_type: null,
+          work_authorization_constraints: [],
+          stack: [],
+          raw_text_excerpt: "x"
+        }),
+        hard_gate_result_json: "{}",
+        values_result_json: null,
+        soft_score_result_json: null,
+        mcp_invocation_id: null,
+        created_at: FIXED_NOW().toISOString()
+      });
+
+      // Second run with a DIFFERENT criteria_version_id → reuse facts.
+      const runId2 = randomUUID();
+      await startDiscovery(repos, {
+        savedSearchId: ssId,
+        runId: runId2,
+        queries: [],
+        connectorById: () => undefined,
+        now: FIXED_NOW
+      });
+      const r2 = recordDiscoveredPostings(repos, {
+        savedSearchId: ssId,
+        runId: runId2,
+        criteria: baseCriteria(),
+        criteriaVersionId: "cv-2", // DIFFERENT — reuse facts, re-run gates+score
+        postings: [posting],
+        now: FIXED_NOW
+      });
+
+      assert.equal(r2.duplicates_skipped, 0);
+      assert.equal(r2.cached_facts_reused, 1);
+      assert.equal(r2.passed_to_eval, 1);
+
+      // The new row carries cached_job_evaluation_id pointing to the
+      // prior evaluation.
+      const newRows = repos.discoveredPostings.listBySearchRun(runId2);
+      assert.equal(newRows[0].cached_job_evaluation_id, evalId);
     } finally {
       conn.close();
     }
@@ -441,6 +552,7 @@ describe("evaluateAllSurvivors", () => {
             is_onsite_required: null,
             employment_type: null,
             inferred_seniority_signals: [],
+            inferred_role_kinds: ["other"],
             raw_metadata: { url: "https://example.com/x" }
           }
         ],
@@ -527,6 +639,7 @@ describe("evaluateAllSurvivors", () => {
             is_onsite_required: null,
             employment_type: null,
             inferred_seniority_signals: [],
+            inferred_role_kinds: ["other"],
             raw_metadata: {}
           },
           {
@@ -540,6 +653,7 @@ describe("evaluateAllSurvivors", () => {
             is_onsite_required: null,
             employment_type: null,
             inferred_seniority_signals: [],
+            inferred_role_kinds: ["other"],
             raw_metadata: {}
           }
         ],
@@ -653,6 +767,7 @@ describe("evaluateAllSurvivors", () => {
             is_onsite_required: null,
             employment_type: null,
             inferred_seniority_signals: [],
+            inferred_role_kinds: ["other"],
             raw_metadata: {}
           }
         ],

--- a/packages/discovery/src/__tests__/role_kind.test.ts
+++ b/packages/discovery/src/__tests__/role_kind.test.ts
@@ -1,0 +1,330 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { inferRoleKindsFromTitle } from "../connector/role_kind.js";
+
+/**
+ * The classifier biases toward false positives. Tests assert MEMBERSHIP
+ * (the expected kind is in the result) rather than equality, so adding
+ * additional matches in the future doesn't break things. Per-tag groups
+ * include 3 positive examples and at least 1 control.
+ */
+function has(title: string, kind: string): boolean {
+  return inferRoleKindsFromTitle(title).includes(kind as never);
+}
+
+describe("inferRoleKindsFromTitle — engineering", () => {
+  it("matches Software Engineer / Backend Engineer / SWE", () => {
+    assert.ok(has("Software Engineer", "engineering"));
+    assert.ok(has("Senior Backend Engineer", "engineering"));
+    assert.ok(has("SWE II, Platform", "engineering"));
+  });
+  it("does NOT classify a Designer as engineering", () => {
+    assert.ok(!has("Product Designer", "engineering"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — research", () => {
+  it("matches Research Engineer / Research Scientist / Researcher", () => {
+    assert.ok(has("Research Engineer, Agents", "research"));
+    assert.ok(has("Research Scientist", "research"));
+    assert.ok(has("AI Researcher", "research"));
+  });
+  it("does NOT classify a Sales Manager as research", () => {
+    assert.ok(!has("Sales Manager", "research"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — ml", () => {
+  it("matches ML Engineer / Applied ML Scientist / Data Scientist", () => {
+    assert.ok(has("ML Engineer", "ml"));
+    assert.ok(has("Applied AI Scientist", "ml"));
+    assert.ok(has("Senior Data Scientist", "ml"));
+  });
+  it("does NOT classify a Sales Manager as ml", () => {
+    assert.ok(!has("Sales Manager", "ml"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — infrastructure", () => {
+  it("matches Infrastructure Engineer / Platform Engineer / SRE", () => {
+    assert.ok(has("Infrastructure Engineer", "infrastructure"));
+    assert.ok(has("Platform Engineer, Distributed Systems", "infrastructure"));
+    assert.ok(has("SRE", "infrastructure"));
+  });
+  it("infrastructure also tags engineering", () => {
+    assert.ok(has("Cloud Engineer", "engineering"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — security", () => {
+  it("matches Security Engineer / AppSec Engineer / Product Security Researcher", () => {
+    assert.ok(has("Security Engineer", "security"));
+    assert.ok(has("AppSec Engineer", "security"));
+    assert.ok(has("Product Security Researcher", "security"));
+  });
+  it("security tag co-occurs with engineering", () => {
+    const kinds = inferRoleKindsFromTitle("Senior Security Engineer");
+    assert.ok(kinds.includes("security"));
+    assert.ok(kinds.includes("engineering"));
+  });
+  it("does NOT match unrelated 'security' words like 'Securities Trader'", () => {
+    // Lone "security" without engineer/architect/researcher does not
+    // trip the gate.
+    assert.ok(!has("Securities Trader", "security"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — design", () => {
+  it("matches Product Designer / UX Designer / Visual Designer", () => {
+    assert.ok(has("Product Designer", "design"));
+    assert.ok(has("Senior UX Designer", "design"));
+    assert.ok(has("Visual Designer", "design"));
+  });
+  it("does NOT classify a Software Engineer as design", () => {
+    assert.ok(!has("Software Engineer", "design"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — product", () => {
+  it("matches Product Manager / TPM / Group Product Manager", () => {
+    assert.ok(has("Product Manager, Growth", "product"));
+    assert.ok(has("Technical Program Manager", "product"));
+    assert.ok(has("Group Product Manager", "product"));
+  });
+  it("does NOT classify lone 'product' words like 'Product Designer' as product", () => {
+    // Product Designer should be design, not product.
+    const kinds = inferRoleKindsFromTitle("Product Designer");
+    assert.ok(kinds.includes("design"));
+    assert.ok(!kinds.includes("product"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — sales", () => {
+  it("matches Account Executive / SDR / Sales Engineer / Solutions Engineer", () => {
+    assert.ok(has("Account Executive, Enterprise", "sales"));
+    assert.ok(has("Senior SDR", "sales"));
+    assert.ok(has("Sales Engineer", "sales"));
+  });
+  it("Solutions Engineer is BOTH sales AND engineering", () => {
+    const kinds = inferRoleKindsFromTitle("Solutions Engineer");
+    assert.ok(kinds.includes("sales"));
+    assert.ok(kinds.includes("engineering"));
+  });
+  it("does NOT classify a Software Engineer as sales", () => {
+    assert.ok(!has("Software Engineer", "sales"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — customer_success", () => {
+  it("matches Customer Success Manager / Onboarding / Implementation Specialist", () => {
+    assert.ok(has("Customer Success Manager", "customer_success"));
+    assert.ok(has("Onboarding Manager", "customer_success"));
+    assert.ok(has("Implementation Specialist", "customer_success"));
+  });
+  it("does NOT classify a Sales Engineer as customer_success", () => {
+    assert.ok(!has("Sales Engineer", "customer_success"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — marketing", () => {
+  it("matches Marketing Manager / Growth Manager / Content Strategist", () => {
+    assert.ok(has("Senior Marketing Manager", "marketing"));
+    assert.ok(has("Growth Manager", "marketing"));
+    assert.ok(has("Content Strategist", "marketing"));
+  });
+  it("does NOT classify a Software Engineer as marketing", () => {
+    assert.ok(!has("Software Engineer", "marketing"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — recruiting", () => {
+  it("matches Recruiter / Talent Acquisition / Sourcer", () => {
+    assert.ok(has("Senior Recruiter", "recruiting"));
+    assert.ok(has("Talent Acquisition Partner", "recruiting"));
+    assert.ok(has("Technical Sourcer", "recruiting"));
+  });
+  it("does NOT classify a Customer Success Manager as recruiting", () => {
+    assert.ok(!has("Customer Success Manager", "recruiting"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — people_ops", () => {
+  it("matches People Operations / HRBP / People Partner", () => {
+    assert.ok(has("People Operations Manager", "people_ops"));
+    assert.ok(has("HRBP, Engineering", "people_ops"));
+    assert.ok(has("Senior People Partner", "people_ops"));
+  });
+  it("does NOT classify a Software Engineer as people_ops", () => {
+    assert.ok(!has("Software Engineer", "people_ops"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — finance", () => {
+  it("matches Finance Manager / Accountant / Controller", () => {
+    assert.ok(has("Finance Manager", "finance"));
+    assert.ok(has("Senior Accountant", "finance"));
+    assert.ok(has("Controller, FP&A", "finance"));
+  });
+  it("does NOT classify a Software Engineer as finance", () => {
+    assert.ok(!has("Software Engineer", "finance"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — legal", () => {
+  it("matches Counsel / Lawyer / Privacy Counsel / Paralegal", () => {
+    assert.ok(has("Senior Counsel, Privacy", "legal"));
+    assert.ok(has("Privacy Counsel", "legal"));
+    assert.ok(has("Paralegal", "legal"));
+  });
+  it("does NOT classify a Sales Engineer as legal", () => {
+    assert.ok(!has("Sales Engineer", "legal"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — operations", () => {
+  it("matches BizOps / Chief of Staff / RevOps", () => {
+    assert.ok(has("Senior BizOps Analyst", "operations"));
+    assert.ok(has("Chief of Staff", "operations"));
+    assert.ok(has("Revenue Operations Manager", "operations"));
+  });
+  it("does NOT classify a Software Engineer as operations", () => {
+    assert.ok(!has("Software Engineer", "operations"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — support", () => {
+  it("matches Technical Support Engineer / Customer Support / Help Desk", () => {
+    assert.ok(has("Technical Support Engineer", "support"));
+    assert.ok(has("Customer Support Engineer", "support"));
+    assert.ok(has("Help Desk Specialist", "support"));
+  });
+  it("does NOT classify a Backend Engineer as support", () => {
+    assert.ok(!has("Backend Engineer", "support"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — data", () => {
+  it("matches Data Engineer / Analytics Engineer / Data Analyst", () => {
+    assert.ok(has("Data Engineer", "data"));
+    assert.ok(has("Analytics Engineer", "data"));
+    assert.ok(has("Senior Data Analyst", "data"));
+  });
+  it("does NOT classify a Data Scientist as data (treated as ml)", () => {
+    const kinds = inferRoleKindsFromTitle("Data Scientist");
+    assert.ok(kinds.includes("ml"));
+    assert.ok(!kinds.includes("data"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — devrel", () => {
+  it("matches Developer Advocate / DevRel Engineer / Developer Experience", () => {
+    assert.ok(has("Developer Advocate", "devrel"));
+    assert.ok(has("DevRel Engineer", "devrel"));
+    assert.ok(has("Developer Experience Lead", "devrel"));
+  });
+  it("does NOT classify a Backend Engineer as devrel", () => {
+    assert.ok(!has("Backend Engineer", "devrel"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — policy", () => {
+  it("matches Policy Manager / Trust & Safety / Public Affairs", () => {
+    assert.ok(has("Senior Policy Manager", "policy"));
+    assert.ok(has("Trust and Safety Lead", "policy"));
+    assert.ok(has("Public Affairs Director", "policy"));
+  });
+  it("does NOT classify a Backend Engineer as policy", () => {
+    assert.ok(!has("Backend Engineer", "policy"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — multi-tag titles", () => {
+  it("Senior Security Engineer tags engineering AND security", () => {
+    const kinds = inferRoleKindsFromTitle("Senior Security Engineer");
+    assert.ok(kinds.includes("engineering"));
+    assert.ok(kinds.includes("security"));
+  });
+  it("Solutions Engineer tags engineering AND sales", () => {
+    const kinds = inferRoleKindsFromTitle("Solutions Engineer");
+    assert.ok(kinds.includes("engineering"));
+    assert.ok(kinds.includes("sales"));
+  });
+  it("Data Engineer tags data AND engineering", () => {
+    const kinds = inferRoleKindsFromTitle("Data Engineer");
+    assert.ok(kinds.includes("data"));
+    assert.ok(kinds.includes("engineering"));
+  });
+});
+
+describe("inferRoleKindsFromTitle — 'other' fallback", () => {
+  it("returns ['other'] for empty title", () => {
+    assert.deepEqual(inferRoleKindsFromTitle(""), ["other"]);
+  });
+  it("returns ['other'] for purely whitespace title", () => {
+    assert.deepEqual(inferRoleKindsFromTitle("   "), ["other"]);
+  });
+  it("returns ['other'] for unrecognized job title", () => {
+    assert.deepEqual(inferRoleKindsFromTitle("Cosmic Ray Whisperer"), [
+      "other"
+    ]);
+  });
+  it("returns ['other'] when no kind regex matches", () => {
+    // "Janitor" doesn't match any tag.
+    assert.deepEqual(inferRoleKindsFromTitle("Janitor"), ["other"]);
+  });
+});
+
+describe("inferRoleKindsFromTitle — case insensitivity & dedup", () => {
+  it("classifies regardless of letter case", () => {
+    assert.ok(inferRoleKindsFromTitle("SOFTWARE ENGINEER").includes("engineering"));
+    assert.ok(inferRoleKindsFromTitle("software engineer").includes("engineering"));
+  });
+  it("dedupes when multiple regex blocks match the same kind", () => {
+    // "Software Engineer" matches engineering via two paths; should
+    // appear only once in the output.
+    const kinds = inferRoleKindsFromTitle("Senior Software Engineer");
+    const engCount = kinds.filter((k) => k === "engineering").length;
+    assert.equal(engCount, 1);
+  });
+});
+
+describe("inferRoleKindsFromTitle — Anthropic Greenhouse exemplars", () => {
+  // Real titles from the Anthropic board (paraphrased) that the
+  // user's blocklist should reject pre-extraction.
+  it("'Account Executive, Startups, EMEA' tags sales", () => {
+    assert.ok(
+      inferRoleKindsFromTitle("Account Executive, Startups, EMEA").includes(
+        "sales"
+      )
+    );
+  });
+  it("'Senior Recruiter, Engineering' tags recruiting", () => {
+    assert.ok(
+      inferRoleKindsFromTitle("Senior Recruiter, Engineering").includes(
+        "recruiting"
+      )
+    );
+  });
+  it("'Customer Success Engineer' tags customer_success", () => {
+    assert.ok(
+      inferRoleKindsFromTitle("Customer Success Engineer").includes(
+        "customer_success"
+      )
+    );
+  });
+  it("'Privacy Counsel' tags legal", () => {
+    assert.ok(inferRoleKindsFromTitle("Privacy Counsel").includes("legal"));
+  });
+  it("'Senior Policy Manager, Public Sector' tags policy", () => {
+    assert.ok(
+      inferRoleKindsFromTitle("Senior Policy Manager, Public Sector").includes(
+        "policy"
+      )
+    );
+  });
+  it("'Research Engineer, Agents' tags research AND engineering", () => {
+    const kinds = inferRoleKindsFromTitle("Research Engineer, Agents");
+    assert.ok(kinds.includes("research"));
+    assert.ok(kinds.includes("engineering"));
+  });
+});

--- a/packages/discovery/src/connector/index.ts
+++ b/packages/discovery/src/connector/index.ts
@@ -12,5 +12,8 @@ export type {
   WorkItem
 } from "./types.js";
 
+export { DEFAULT_MAX_RESULTS } from "./types.js";
+
 export { inferSeniorityFromTitle } from "./seniority.js";
+export { inferRoleKindsFromTitle } from "./role_kind.js";
 export { htmlToText } from "./html.js";

--- a/packages/discovery/src/connector/role_kind.ts
+++ b/packages/discovery/src/connector/role_kind.ts
@@ -1,0 +1,260 @@
+import type { RoleKind } from "@networkpipeline/criteria";
+
+/**
+ * Best-effort title -> RoleKind classifier. Pure regex, no LLM, no
+ * description body needed. Returns ALL matched kinds.
+ *
+ * Multi-tag is intentional: a "Senior Security Engineer" matches BOTH
+ * `engineering` AND `security`; a "Solutions Engineer" matches BOTH
+ * `engineering` AND `sales`. The user's blocklist (must_not_have.role_kind)
+ * decides which tags reject — over-tagging is the safe failure mode.
+ *
+ * Returns `["other"]` when nothing matches. Pre-extraction treats this
+ * as a defer (no rejection) — same defer-on-ambiguity contract as
+ * role_seniority with empty signals.
+ *
+ * Order of regex blocks below is irrelevant — every match contributes;
+ * dedup happens via Set.
+ */
+export function inferRoleKindsFromTitle(title: string): RoleKind[] {
+  if (!title || title.trim().length === 0) return ["other"];
+  const lower = title.toLowerCase();
+  const out = new Set<RoleKind>();
+
+  // ── engineering ──────────────────────────────────────────────────
+  // Catches "Software Engineer", "Backend Engineer", "Full-Stack Eng",
+  // "Engineering Manager", "SWE", "SDE", and the common "<seniority>
+  // Engineer" / "Engineer, <area>" shapes. Deliberately broad — sales
+  // and customer-success roles often borrow "engineer" (Solutions
+  // Engineer, Sales Engineer); they get tagged BOTH so the blocklist
+  // can route correctly.
+  if (
+    /\b(software|backend|frontend|full[\s-]?stack|web|mobile|ios|android|systems|distributed|cloud|platform|api)[\s-]+(engineer|developer|swe|sde)\b/.test(
+      lower
+    ) ||
+    /\b(swe|sde)\b/.test(lower) ||
+    /\b(engineer|engineering)\b/.test(lower) ||
+    /\b(developer)\b/.test(lower) ||
+    /\b(software architect|technical lead|tech lead)\b/.test(lower)
+  ) {
+    out.add("engineering");
+  }
+
+  // ── research ─────────────────────────────────────────────────────
+  if (
+    /\bresearch (engineer|scientist|associate|fellow|lead|manager|director)\b/.test(
+      lower
+    ) ||
+    /\b(researcher|research intern)\b/.test(lower) ||
+    /\bmember of technical staff\b/.test(lower)
+  ) {
+    out.add("research");
+  }
+
+  // ── ml ───────────────────────────────────────────────────────────
+  // ML / AI / applied-scientist roles. We deliberately tag these as
+  // `ml` AND `engineering` when "engineer" appears so that a blocklist
+  // of `[sales, marketing, ...]` (which excludes `ml`) lets them pass.
+  if (
+    /\b(ml|machine[\s-]?learning|ai|applied[\s-]?(ml|ai|scientist)|deep[\s-]?learning|nlp|computer[\s-]?vision|model)\b.*\b(engineer|scientist|researcher|developer|architect)\b/.test(
+      lower
+    ) ||
+    /\b(data scientist|ai engineer|ml engineer|mlops)\b/.test(lower)
+  ) {
+    out.add("ml");
+  }
+
+  // ── infrastructure ───────────────────────────────────────────────
+  if (
+    /\b(infrastructure|infra|platform|sre|site[\s-]?reliability|devops|cloud|kubernetes|distributed[\s-]?systems)[\s-]+(engineer|architect|specialist)\b/.test(
+      lower
+    ) ||
+    /\b(infrastructure engineer|platform engineer|sre|reliability engineer|devops engineer|cloud engineer)\b/.test(
+      lower
+    ) ||
+    /\bmember of technical staff,?\s+(infrastructure|platform|distributed)\b/.test(
+      lower
+    )
+  ) {
+    out.add("infrastructure");
+    out.add("engineering");
+  }
+
+  // ── security ─────────────────────────────────────────────────────
+  // Security roles also get the engineering tag — most postings are
+  // engineering-flavored even when they're labeled "Security Engineer"
+  // or "AppSec Researcher".
+  if (
+    /\b(security|appsec|infosec|cyber[\s-]?security|product[\s-]?security|application[\s-]?security)\b.*\b(engineer|architect|researcher|analyst|specialist|lead|manager)\b/.test(
+      lower
+    ) ||
+    /\b(security engineer|security researcher|security architect|appsec engineer|infosec engineer)\b/.test(
+      lower
+    )
+  ) {
+    out.add("security");
+    out.add("engineering");
+  }
+
+  // ── design ───────────────────────────────────────────────────────
+  if (
+    /\b(designer|ux|ui|product[\s-]?designer|visual[\s-]?designer|interaction[\s-]?designer|design[\s-]?lead)\b/.test(
+      lower
+    )
+  ) {
+    out.add("design");
+  }
+
+  // ── product ──────────────────────────────────────────────────────
+  // Be careful: PM is too generic — only match when in the context of
+  // a job title (start/end of word, paired with "manager", or as TPM/PM
+  // in a product context). The lone "pm" alone is too noisy.
+  if (
+    /\bproduct[\s-]?(manager|owner|lead|director)\b/.test(lower) ||
+    /\b(tpm|technical[\s-]?program[\s-]?manager|technical[\s-]?product[\s-]?manager)\b/.test(
+      lower
+    ) ||
+    /\b(group product manager|gpm)\b/.test(lower)
+  ) {
+    out.add("product");
+  }
+
+  // ── sales ────────────────────────────────────────────────────────
+  if (
+    /\b(account[\s-]?executive|ae|sdr|bdr|account[\s-]?manager|sales[\s-]?(engineer|manager|representative|rep|lead|director|specialist)|business[\s-]?development|sales[\s-]?development)\b/.test(
+      lower
+    ) ||
+    /\b(solutions[\s-]?(engineer|architect|consultant))\b/.test(lower) ||
+    /\b(enterprise sales|sales|inside sales|outbound sales)\b/.test(lower)
+  ) {
+    out.add("sales");
+    // Solutions Engineer / Sales Engineer also tag as engineering so
+    // a search blocking sales but NOT engineering can still surface
+    // the engineering side; that conflict is for the user's blocklist
+    // to decide.
+    if (/\bsolutions[\s-]?engineer|sales[\s-]?engineer\b/.test(lower)) {
+      out.add("engineering");
+    }
+  }
+
+  // ── customer_success ─────────────────────────────────────────────
+  if (
+    /\b(customer[\s-]?success|customer[\s-]?experience|onboarding|implementation[\s-]?(specialist|engineer|consultant|manager)|cx|csm)\b/.test(
+      lower
+    ) ||
+    /\bcustomer[\s-]?(experience|success|support|operations)[\s-]?(manager|lead|director)\b/.test(
+      lower
+    )
+  ) {
+    out.add("customer_success");
+    if (/\bimplementation[\s-]?engineer\b/.test(lower)) {
+      out.add("engineering");
+    }
+  }
+
+  // ── marketing ────────────────────────────────────────────────────
+  if (
+    /\b(marketing|brand|growth|content[\s-]?(strategist|writer|marketer|marketing|lead|director)|seo|community[\s-]?manager|product[\s-]?marketing)\b/.test(
+      lower
+    ) ||
+    /\b(marketing manager|marketing lead|marketing director|growth manager|brand manager|head of marketing)\b/.test(
+      lower
+    )
+  ) {
+    out.add("marketing");
+  }
+
+  // ── recruiting ───────────────────────────────────────────────────
+  if (
+    /\b(recruiter|recruiting|talent[\s-]?(acquisition|partner|sourcer)|sourcer|technical[\s-]?recruiter|head[\s-]?of[\s-]?talent)\b/.test(
+      lower
+    )
+  ) {
+    out.add("recruiting");
+  }
+
+  // ── people_ops ───────────────────────────────────────────────────
+  if (
+    /\b(people[\s-]?(operations|ops|partner|team)|hr|hrbp|human[\s-]?resources|people[\s-]?(manager|lead|director)|head[\s-]?of[\s-]?people|chief[\s-]?people[\s-]?officer)\b/.test(
+      lower
+    )
+  ) {
+    out.add("people_ops");
+  }
+
+  // ── finance ──────────────────────────────────────────────────────
+  if (
+    /\b(finance|accountant|accounting|fp&a|controller|treasur(y|er)|tax[\s-]?(manager|analyst|director)|cfo|head[\s-]?of[\s-]?finance|financial[\s-]?(analyst|planner))\b/.test(
+      lower
+    )
+  ) {
+    out.add("finance");
+  }
+
+  // ── legal ────────────────────────────────────────────────────────
+  if (
+    /\b(counsel|lawyer|legal[\s-]?(ops|operations|counsel|director|manager)|paralegal|privacy[\s-]?counsel|general[\s-]?counsel)\b/.test(
+      lower
+    )
+  ) {
+    out.add("legal");
+  }
+
+  // ── operations ───────────────────────────────────────────────────
+  if (
+    /\b(bizops|business[\s-]?(operations|ops|analyst)|chief[\s-]?of[\s-]?staff|strategy[\s-]?(operations|ops|lead|manager|director)|operations[\s-]?(manager|lead|director|analyst)|coo|head[\s-]?of[\s-]?operations|revenue[\s-]?operations|revops)\b/.test(
+      lower
+    )
+  ) {
+    out.add("operations");
+  }
+
+  // ── support ──────────────────────────────────────────────────────
+  if (
+    /\b(support[\s-]?(engineer|specialist|representative|manager|lead|director)|technical[\s-]?support|help[\s-]?desk|customer[\s-]?support[\s-]?engineer)\b/.test(
+      lower
+    )
+  ) {
+    out.add("support");
+    if (/\b(support[\s-]?engineer|technical[\s-]?support[\s-]?engineer)\b/.test(lower)) {
+      out.add("engineering");
+    }
+  }
+
+  // ── data ─────────────────────────────────────────────────────────
+  if (
+    /\b(data[\s-]?(engineer|analyst|architect|platform[\s-]?engineer)|analytics[\s-]?engineer|analytics[\s-]?(analyst|lead|manager)|business[\s-]?intelligence|bi[\s-]?(engineer|analyst|developer))\b/.test(
+      lower
+    )
+  ) {
+    out.add("data");
+    if (
+      /\b(data[\s-]?engineer|analytics[\s-]?engineer|data[\s-]?platform[\s-]?engineer)\b/.test(
+        lower
+      )
+    ) {
+      out.add("engineering");
+    }
+  }
+
+  // ── devrel ───────────────────────────────────────────────────────
+  if (
+    /\b(developer[\s-]?(advocate|relations|experience|evangelist)|devrel|dx[\s-]?engineer|community[\s-]?(engineer|advocate))\b/.test(
+      lower
+    )
+  ) {
+    out.add("devrel");
+  }
+
+  // ── policy ───────────────────────────────────────────────────────
+  if (
+    /\b(policy[\s-]?(manager|lead|analyst|director|advisor)|trust[\s\-_]?(and[\s-]?)?safety|t&s|public[\s-]?affairs|government[\s-]?affairs|public[\s-]?policy|head[\s-]?of[\s-]?policy)\b/.test(
+      lower
+    )
+  ) {
+    out.add("policy");
+  }
+
+  if (out.size === 0) return ["other"];
+  return [...out];
+}

--- a/packages/discovery/src/connector/types.ts
+++ b/packages/discovery/src/connector/types.ts
@@ -1,4 +1,4 @@
-import type { SeniorityBand } from "@networkpipeline/criteria";
+import type { RoleKind, SeniorityBand } from "@networkpipeline/criteria";
 
 export type SourceId =
   | "indeed"
@@ -93,6 +93,13 @@ export type NormalizedDiscoveredPosting = {
     | "internship"
     | null;
   inferred_seniority_signals: SeniorityBand[];
+  /**
+   * Best-effort title-classifier output for the deterministic
+   * `role_kind` pre-extraction gate. Multi-tag is fine — see
+   * `inferRoleKindsFromTitle` for the contract. `["other"]` means
+   * "title didn't match any kind"; the gate treats that as a defer.
+   */
+  inferred_role_kinds: RoleKind[];
   /** Verbatim source response, JSON-serializable. Persisted to discovered_postings.raw_metadata_json. */
   raw_metadata: Record<string, unknown>;
 };
@@ -117,19 +124,51 @@ export interface SourceConnector {
   description(): string;
 }
 
+/**
+ * Default per-search result cap when SavedSearch.max_results is null.
+ * Tuned to keep typical run cost under $0.50 even on a fanned-out
+ * search across 6 sources. Configurable via SavedSearch.max_results
+ * up to a hard ceiling of 500.
+ */
+export const DEFAULT_MAX_RESULTS = 50;
+
 export interface InstructionSourceConnector extends SourceConnector {
   kind: "instruction";
-  discoverInstruction(query: SourceQuery, runId: string): IngestInstruction;
+  /**
+   * `maxResults` is the per-search posting cap. Defaults to
+   * DEFAULT_MAX_RESULTS. Instruction connectors forward it to the
+   * downstream Claude tool (e.g., Indeed `limit` arg) AND truncate
+   * their `recordResults` output to be safe.
+   */
+  discoverInstruction(
+    query: SourceQuery,
+    runId: string,
+    maxResults?: number
+  ): IngestInstruction;
   /**
    * Called by the orchestrator with the raw payload Claude returns
    * after executing the instruction. Returns the normalized postings.
+   * Truncates to `maxResults` (default DEFAULT_MAX_RESULTS) so an
+   * over-eager Claude can't blow past the cap.
    */
-  recordResults(payload: unknown): NormalizedDiscoveredPosting[];
+  recordResults(
+    payload: unknown,
+    maxResults?: number
+  ): NormalizedDiscoveredPosting[];
 }
 
 export interface DirectFetchSourceConnector extends SourceConnector {
   kind: "direct";
-  discoverDirect(query: SourceQuery): Promise<DirectFetchResult>;
+  /**
+   * `maxResults` is the per-search posting cap. Defaults to
+   * DEFAULT_MAX_RESULTS. Connectors fetch normally and truncate the
+   * normalized result list AFTER mapping (so the truncation is on
+   * the SAME order the source returned, not random).
+   */
+  discoverDirect(
+    query: SourceQuery,
+    maxResults?: number
+  ): Promise<DirectFetchResult>;
 }
 
 export type AnyConnector =

--- a/packages/discovery/src/connectors/ashby.ts
+++ b/packages/discovery/src/connectors/ashby.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
 import { htmlToText } from "../connector/html.js";
+import { inferRoleKindsFromTitle } from "../connector/role_kind.js";
 import { inferSeniorityFromTitle } from "../connector/seniority.js";
-import type {
-  DirectFetchResult,
-  DirectFetchSourceConnector,
-  FetchImpl,
-  NormalizedDiscoveredPosting,
-  SourceQuery
+import {
+  DEFAULT_MAX_RESULTS,
+  type DirectFetchResult,
+  type DirectFetchSourceConnector,
+  type FetchImpl,
+  type NormalizedDiscoveredPosting,
+  type SourceQuery
 } from "../connector/types.js";
 
 /**
@@ -50,7 +52,10 @@ export function ashbyConnector(
     description() {
       return "Ashby public job-board posting-api connector (https://api.ashbyhq.com/posting-api/job-board).";
     },
-    async discoverDirect(query: SourceQuery): Promise<DirectFetchResult> {
+    async discoverDirect(
+      query: SourceQuery,
+      maxResults: number = DEFAULT_MAX_RESULTS
+    ): Promise<DirectFetchResult> {
       if (query.source !== "ashby") {
         return {
           kind: "direct_fetch_result",
@@ -132,9 +137,9 @@ export function ashbyConnector(
           ]
         };
       }
-      const postings = parsed.data.jobs.map((job) =>
-        normalizeAshbyJob(job, slug)
-      );
+      const postings = parsed.data.jobs
+        .map((job) => normalizeAshbyJob(job, slug))
+        .slice(0, maxResults);
       return {
         kind: "direct_fetch_result",
         source: "ashby",
@@ -179,6 +184,7 @@ function normalizeAshbyJob(
     is_onsite_required: isOnsiteRequired,
     employment_type: mapAshbyEmploymentType(job.employmentType ?? null),
     inferred_seniority_signals: inferSeniorityFromTitle(job.title),
+    inferred_role_kinds: inferRoleKindsFromTitle(job.title),
     raw_metadata: { ...job }
   };
 }

--- a/packages/discovery/src/connectors/career_page.ts
+++ b/packages/discovery/src/connectors/career_page.ts
@@ -1,11 +1,13 @@
 import { z } from "zod";
 import { htmlToText } from "../connector/html.js";
+import { inferRoleKindsFromTitle } from "../connector/role_kind.js";
 import { inferSeniorityFromTitle } from "../connector/seniority.js";
-import type {
-  IngestInstruction,
-  InstructionSourceConnector,
-  NormalizedDiscoveredPosting,
-  SourceQuery
+import {
+  DEFAULT_MAX_RESULTS,
+  type IngestInstruction,
+  type InstructionSourceConnector,
+  type NormalizedDiscoveredPosting,
+  type SourceQuery
 } from "../connector/types.js";
 
 /**
@@ -66,13 +68,17 @@ export function careerPageConnector(
     },
     discoverInstruction(
       query: SourceQuery,
-      runId: string
+      runId: string,
+      _maxResults?: number
     ): IngestInstruction {
       if (query.source !== "career_page") {
         throw new Error(
           `careerPageConnector: expected query.source === "career_page", got "${query.source}"`
         );
       }
+      // The career-page connector has no upstream "limit" knob — Claude
+      // crawls whatever the URL exposes. Truncation happens in
+      // recordResults below.
       return {
         kind: "ingest_instruction",
         source: "career_page",
@@ -86,12 +92,15 @@ export function careerPageConnector(
         search_run_id: runId
       };
     },
-    recordResults(payload: unknown): NormalizedDiscoveredPosting[] {
+    recordResults(
+      payload: unknown,
+      maxResults: number = DEFAULT_MAX_RESULTS
+    ): NormalizedDiscoveredPosting[] {
       const parsed = careerPagePayloadSchema.safeParse(payload);
       if (!parsed.success) return [];
-      return parsed.data.postings.map((p) =>
-        normalizeCareerPagePosting(p, opts.defaultCompany)
-      );
+      return parsed.data.postings
+        .slice(0, maxResults)
+        .map((p) => normalizeCareerPagePosting(p, opts.defaultCompany));
     }
   };
 }
@@ -126,6 +135,7 @@ function normalizeCareerPagePosting(
     is_onsite_required: isOnsiteRequired,
     employment_type: mapEmploymentTypeHint(posting.employment_type_hint ?? null),
     inferred_seniority_signals: inferSeniorityFromTitle(posting.title),
+    inferred_role_kinds: inferRoleKindsFromTitle(posting.title),
     raw_metadata: { ...posting }
   };
 }

--- a/packages/discovery/src/connectors/greenhouse.ts
+++ b/packages/discovery/src/connectors/greenhouse.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
 import { htmlToText } from "../connector/html.js";
+import { inferRoleKindsFromTitle } from "../connector/role_kind.js";
 import { inferSeniorityFromTitle } from "../connector/seniority.js";
-import type {
-  DirectFetchResult,
-  DirectFetchSourceConnector,
-  FetchImpl,
-  NormalizedDiscoveredPosting,
-  SourceQuery
+import {
+  DEFAULT_MAX_RESULTS,
+  type DirectFetchResult,
+  type DirectFetchSourceConnector,
+  type FetchImpl,
+  type NormalizedDiscoveredPosting,
+  type SourceQuery
 } from "../connector/types.js";
 
 /**
@@ -69,7 +71,10 @@ export function greenhouseConnector(
     description() {
       return "Greenhouse public boards-api connector (https://boards-api.greenhouse.io).";
     },
-    async discoverDirect(query: SourceQuery): Promise<DirectFetchResult> {
+    async discoverDirect(
+      query: SourceQuery,
+      maxResults: number = DEFAULT_MAX_RESULTS
+    ): Promise<DirectFetchResult> {
       if (query.source !== "greenhouse") {
         return {
           kind: "direct_fetch_result",
@@ -147,9 +152,14 @@ export function greenhouseConnector(
           ]
         };
       }
-      const postings = parsed.data.jobs.map((job) =>
-        normalizeGreenhouseJob(job, slug)
-      );
+      // Map first, THEN truncate so the cap reflects the source's
+      // own ordering. Greenhouse returns active jobs sorted by their
+      // internal ordering (not by date) — truncating raw before mapping
+      // would be equivalent here, but keeping the map+slice order
+      // matches the contract described in DirectFetchSourceConnector.
+      const postings = parsed.data.jobs
+        .map((job) => normalizeGreenhouseJob(job, slug))
+        .slice(0, maxResults);
       return {
         kind: "direct_fetch_result",
         source: "greenhouse",
@@ -186,6 +196,7 @@ function normalizeGreenhouseJob(
     is_onsite_required: isOnsiteRequired,
     employment_type: extractEmploymentType(job.metadata ?? null),
     inferred_seniority_signals: inferSeniorityFromTitle(job.title),
+    inferred_role_kinds: inferRoleKindsFromTitle(job.title),
     raw_metadata: { ...job }
   };
 }

--- a/packages/discovery/src/connectors/indeed.ts
+++ b/packages/discovery/src/connectors/indeed.ts
@@ -1,17 +1,22 @@
 import { z } from "zod";
 import { htmlToText } from "../connector/html.js";
+import { inferRoleKindsFromTitle } from "../connector/role_kind.js";
 import { inferSeniorityFromTitle } from "../connector/seniority.js";
-import type {
-  IngestInstruction,
-  InstructionSourceConnector,
-  NormalizedDiscoveredPosting,
-  SourceQuery
+import {
+  DEFAULT_MAX_RESULTS,
+  type IngestInstruction,
+  type InstructionSourceConnector,
+  type NormalizedDiscoveredPosting,
+  type SourceQuery
 } from "../connector/types.js";
 
 /**
- * Default per-search result cap. Tunable via factory options later.
+ * Per-connector default cap when neither the SavedSearch nor the
+ * IndeedConnectorOptions override it. Indeed's MCP `limit` parameter
+ * accepts arbitrary positive integers; we default to the package-wide
+ * DEFAULT_MAX_RESULTS so behavior matches the other connectors.
  */
-const DEFAULT_LIMIT = 25;
+const DEFAULT_LIMIT = DEFAULT_MAX_RESULTS;
 
 /**
  * Schema for the Indeed MCP tool response. The Anthropic-hosted
@@ -36,7 +41,12 @@ const indeedSearchResponseSchema = z.object({
 });
 
 export type IndeedConnectorOptions = {
-  /** Per-search result cap forwarded to the Indeed MCP. Default 25. */
+  /**
+   * Per-search result cap forwarded to the Indeed MCP. Default
+   * DEFAULT_MAX_RESULTS (50). Overridden per-call by the orchestrator
+   * via the `maxResults` arg on `discoverInstruction` when the
+   * SavedSearch sets a smaller cap.
+   */
   limit?: number;
 };
 
@@ -60,16 +70,20 @@ export function indeedConnector(
     },
     discoverInstruction(
       query: SourceQuery,
-      runId: string
+      runId: string,
+      maxResults?: number
     ): IngestInstruction {
       if (query.source !== "indeed") {
         throw new Error(
           `indeedConnector: expected query.source === "indeed", got "${query.source}"`
         );
       }
+      // Per-call cap takes precedence over the factory default. This
+      // is how a SavedSearch.max_results=10 reaches the MCP `limit` arg.
+      const effectiveLimit = maxResults ?? limit;
       const args: Record<string, unknown> = {
         query: query.query,
-        limit
+        limit: effectiveLimit
       };
       if (query.location !== undefined) args.location = query.location;
       return {
@@ -86,10 +100,13 @@ export function indeedConnector(
         search_run_id: runId
       };
     },
-    recordResults(payload: unknown): NormalizedDiscoveredPosting[] {
+    recordResults(
+      payload: unknown,
+      maxResults: number = DEFAULT_MAX_RESULTS
+    ): NormalizedDiscoveredPosting[] {
       const parsed = indeedSearchResponseSchema.safeParse(payload);
       if (!parsed.success) return [];
-      return parsed.data.jobs.map(normalizeIndeedJob);
+      return parsed.data.jobs.slice(0, maxResults).map(normalizeIndeedJob);
     }
   };
 }
@@ -119,6 +136,7 @@ function normalizeIndeedJob(
     is_onsite_required: isOnsiteRequired,
     employment_type: inferEmploymentType(snippet, job.title),
     inferred_seniority_signals: inferSeniorityFromTitle(job.title),
+    inferred_role_kinds: inferRoleKindsFromTitle(job.title),
     raw_metadata: { ...job }
   };
 }

--- a/packages/discovery/src/connectors/lever.ts
+++ b/packages/discovery/src/connectors/lever.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
 import { htmlToText } from "../connector/html.js";
+import { inferRoleKindsFromTitle } from "../connector/role_kind.js";
 import { inferSeniorityFromTitle } from "../connector/seniority.js";
-import type {
-  DirectFetchResult,
-  DirectFetchSourceConnector,
-  FetchImpl,
-  NormalizedDiscoveredPosting,
-  SourceQuery
+import {
+  DEFAULT_MAX_RESULTS,
+  type DirectFetchResult,
+  type DirectFetchSourceConnector,
+  type FetchImpl,
+  type NormalizedDiscoveredPosting,
+  type SourceQuery
 } from "../connector/types.js";
 
 /**
@@ -57,7 +59,10 @@ export function leverConnector(
     description() {
       return "Lever public postings API connector (https://api.lever.co/v0/postings).";
     },
-    async discoverDirect(query: SourceQuery): Promise<DirectFetchResult> {
+    async discoverDirect(
+      query: SourceQuery,
+      maxResults: number = DEFAULT_MAX_RESULTS
+    ): Promise<DirectFetchResult> {
       if (query.source !== "lever") {
         return {
           kind: "direct_fetch_result",
@@ -135,7 +140,9 @@ export function leverConnector(
           ]
         };
       }
-      const postings = parsed.data.map((p) => normalizeLeverPosting(p, slug));
+      const postings = parsed.data
+        .map((p) => normalizeLeverPosting(p, slug))
+        .slice(0, maxResults);
       return {
         kind: "direct_fetch_result",
         source: "lever",
@@ -183,6 +190,7 @@ function normalizeLeverPosting(
     is_onsite_required: isOnsiteRequired,
     employment_type: mapLeverCommitment(cats.commitment ?? null),
     inferred_seniority_signals: inferSeniorityFromTitle(posting.text),
+    inferred_role_kinds: inferRoleKindsFromTitle(posting.text),
     raw_metadata: { ...posting }
   };
 }

--- a/packages/discovery/src/connectors/manual_paste.ts
+++ b/packages/discovery/src/connectors/manual_paste.ts
@@ -1,9 +1,10 @@
 import { canonicalizeUrl } from "../dedup.js";
-import type {
-  DirectFetchResult,
-  DirectFetchSourceConnector,
-  NormalizedDiscoveredPosting,
-  SourceQuery
+import {
+  DEFAULT_MAX_RESULTS,
+  type DirectFetchResult,
+  type DirectFetchSourceConnector,
+  type NormalizedDiscoveredPosting,
+  type SourceQuery
 } from "../connector/types.js";
 
 /**
@@ -26,7 +27,10 @@ export function manualPasteConnector(): DirectFetchSourceConnector {
     description() {
       return "Manual-paste connector. Synthesizes discovered_postings rows from user-supplied URLs without fetching them — Claude pulls bodies via WebFetch during evaluation.";
     },
-    async discoverDirect(query: SourceQuery): Promise<DirectFetchResult> {
+    async discoverDirect(
+      query: SourceQuery,
+      maxResults: number = DEFAULT_MAX_RESULTS
+    ): Promise<DirectFetchResult> {
       if (query.source !== "manual_paste") {
         return {
           kind: "direct_fetch_result",
@@ -64,7 +68,7 @@ export function manualPasteConnector(): DirectFetchSourceConnector {
       return {
         kind: "direct_fetch_result",
         source: "manual_paste",
-        postings,
+        postings: postings.slice(0, maxResults),
         errors
       };
     }
@@ -83,6 +87,8 @@ function buildManualPastePosting(url: string): NormalizedDiscoveredPosting {
     is_onsite_required: null,
     employment_type: null,
     inferred_seniority_signals: [],
+    // Manual paste has no title beyond the placeholder; defer.
+    inferred_role_kinds: ["other"],
     raw_metadata: { url }
   };
 }

--- a/packages/discovery/src/connectors/recruiter_email.ts
+++ b/packages/discovery/src/connectors/recruiter_email.ts
@@ -1,11 +1,13 @@
 import { z } from "zod";
 import { htmlToText } from "../connector/html.js";
+import { inferRoleKindsFromTitle } from "../connector/role_kind.js";
 import { inferSeniorityFromTitle } from "../connector/seniority.js";
-import type {
-  IngestInstruction,
-  InstructionSourceConnector,
-  NormalizedDiscoveredPosting,
-  SourceQuery
+import {
+  DEFAULT_MAX_RESULTS,
+  type IngestInstruction,
+  type InstructionSourceConnector,
+  type NormalizedDiscoveredPosting,
+  type SourceQuery
 } from "../connector/types.js";
 
 /**
@@ -89,7 +91,8 @@ export function recruiterEmailConnector(
     },
     discoverInstruction(
       query: SourceQuery,
-      runId: string
+      runId: string,
+      maxResults?: number
     ): IngestInstruction {
       if (query.source !== "recruiter_email") {
         throw new Error(
@@ -97,6 +100,8 @@ export function recruiterEmailConnector(
         );
       }
       const gmailQuery = query.gmail_query?.trim() || DEFAULT_RECRUITER_QUERY;
+      // Per-call cap takes precedence over the factory default.
+      const effectiveMaxThreads = maxResults ?? maxThreads;
       return {
         kind: "ingest_instruction",
         source: "recruiter_email",
@@ -106,7 +111,7 @@ export function recruiterEmailConnector(
             tool: "mcp__claude_ai_Gmail__search_threads",
             args: {
               query: gmailQuery,
-              max_threads: maxThreads
+              max_threads: effectiveMaxThreads
             }
           }
         ],
@@ -114,7 +119,10 @@ export function recruiterEmailConnector(
         search_run_id: runId
       };
     },
-    recordResults(payload: unknown): NormalizedDiscoveredPosting[] {
+    recordResults(
+      payload: unknown,
+      maxResults: number = DEFAULT_MAX_RESULTS
+    ): NormalizedDiscoveredPosting[] {
       const parsed = recruiterEmailPayloadSchema.safeParse(payload);
       if (!parsed.success) return [];
       const out: NormalizedDiscoveredPosting[] = [];
@@ -126,6 +134,7 @@ export function recruiterEmailConnector(
         if (!thread.posting.title || thread.posting.title.trim().length === 0)
           continue;
         out.push(normalizeRecruiterEmailPosting(thread));
+        if (out.length >= maxResults) break;
       }
       return out;
     }
@@ -165,6 +174,7 @@ function normalizeRecruiterEmailPosting(
     is_onsite_required: isOnsiteRequired,
     employment_type: mapEmploymentTypeHint(posting.employment_type_hint ?? null),
     inferred_seniority_signals: inferSeniorityFromTitle(posting.title),
+    inferred_role_kinds: inferRoleKindsFromTitle(posting.title),
     raw_metadata: { ...thread }
   };
 }

--- a/packages/discovery/src/dedup.ts
+++ b/packages/discovery/src/dedup.ts
@@ -1,3 +1,6 @@
+import { createHash } from "node:crypto";
+import type { NormalizedDiscoveredPosting } from "./connector/types.js";
+
 /**
  * Tracking-param prefixes stripped from query strings during URL
  * canonicalization. Anything starting with one of these is removed
@@ -64,4 +67,31 @@ export function canonicalizeUrl(input: string): string {
   }
 
   return parsed.toString();
+}
+
+/**
+ * Compute a stable extraction-cache key for a posting. The hash covers
+ * the body that the LLM extractor sees (title + company + first 2KB of
+ * the description excerpt) and is criteria-agnostic — exactly what
+ * `extractor_version` + `input_hash` keys the job_evaluations cache by.
+ *
+ * Used by the orchestrator's three-branch dedup logic in
+ * `recordDiscoveredPostings`:
+ *   - same input_hash + same criteria_version → mark duplicate, skip
+ *   - same input_hash + DIFFERENT criteria_version → reuse facts, skip
+ *     extract LLM call, re-run gates+values+score against the new
+ *     criteria
+ *   - no match → run the full pipeline
+ *
+ * Lowercases and trims so trivial whitespace differences don't bust the
+ * cache. The 2KB cap matches the size connectors store in
+ * `description_excerpt`.
+ */
+export function computePostingInputHash(p: NormalizedDiscoveredPosting): string {
+  const canonical = [
+    p.title.trim().toLowerCase(),
+    p.company.trim().toLowerCase(),
+    (p.description_excerpt ?? "").slice(0, 2048).trim().toLowerCase()
+  ].join("\n---\n");
+  return createHash("sha256").update(canonical).digest("hex");
 }

--- a/packages/discovery/src/index.ts
+++ b/packages/discovery/src/index.ts
@@ -12,9 +12,12 @@ export type {
   WorkItem
 } from "./connector/types.js";
 
+export { DEFAULT_MAX_RESULTS } from "./connector/types.js";
+
 export { inferSeniorityFromTitle } from "./connector/seniority.js";
+export { inferRoleKindsFromTitle } from "./connector/role_kind.js";
 export { htmlToText } from "./connector/html.js";
-export { canonicalizeUrl } from "./dedup.js";
+export { canonicalizeUrl, computePostingInputHash } from "./dedup.js";
 
 export { indeedConnector, type IndeedConnectorOptions } from "./connectors/indeed.js";
 export {

--- a/packages/discovery/src/orchestrator.ts
+++ b/packages/discovery/src/orchestrator.ts
@@ -11,7 +11,16 @@ import type {
   EvaluationResult,
   JsonOutputProvider
 } from "@networkpipeline/evaluator";
-import { evaluateJob, preExtractionGateCheck } from "@networkpipeline/evaluator";
+import {
+  EXTRACTOR_VERSION,
+  evaluateJob,
+  evaluateJobWithCachedFacts,
+  hashPostingText,
+  preExtractionGateCheck
+} from "@networkpipeline/evaluator";
+import type { ExtractedJobFacts } from "@networkpipeline/evaluator";
+import { inferRoleKindsFromTitle } from "./connector/role_kind.js";
+import { inferSeniorityFromTitle } from "./connector/seniority.js";
 import type {
   AnyConnector,
   IngestInstruction,
@@ -19,6 +28,14 @@ import type {
   SourceId,
   SourceQuery
 } from "./connector/types.js";
+
+function extractStringField(
+  raw: Record<string, unknown>,
+  key: string
+): string | null {
+  const v = raw[key];
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
 
 export type DiscoveryRepositories = {
   savedSearches: SavedSearchesRepository;
@@ -67,6 +84,13 @@ export type StartDiscoveryOptions = {
   queries: SourceQuery[];
   /** Connector lookup; tests inject mocks. */
   connectorById: (id: SourceId) => AnyConnector | undefined;
+  /**
+   * Per-search result cap, forwarded to every connector. Caps direct
+   * fetches via `discoverDirect(query, maxResults)` and instructions
+   * via `discoverInstruction(query, runId, maxResults)`. Defaults to
+   * the connector-side fallback (DEFAULT_MAX_RESULTS = 50).
+   */
+  maxResults?: number;
   /** Override new Date() for deterministic tests. Defaults to () => new Date(). */
   now?: () => Date;
 };
@@ -133,7 +157,7 @@ export async function startDiscovery(
       continue;
     }
     if (connector.kind === "direct") {
-      const result = await connector.discoverDirect(query);
+      const result = await connector.discoverDirect(query, options.maxResults);
       direct_postings.push(...result.postings);
       for (const e of result.errors) {
         direct_errors.push({
@@ -143,7 +167,9 @@ export async function startDiscovery(
         });
       }
     } else {
-      instructions.push(connector.discoverInstruction(query, options.runId));
+      instructions.push(
+        connector.discoverInstruction(query, options.runId, options.maxResults)
+      );
     }
   }
 
@@ -155,6 +181,14 @@ export type RecordOptions = {
   runId: string;
   postings: NormalizedDiscoveredPosting[];
   criteria: CandidateCriteria;
+  /**
+   * Current criteria_version_id. When supplied, recordDiscoveredPostings
+   * checks for prior job_evaluations with this exact criteria version
+   * (treats those as "duplicate, skip evaluation"). When omitted, the
+   * cross-criteria-version cache lookup still runs but the
+   * same-criteria-skip path is disabled.
+   */
+  criteriaVersionId?: string | null;
   /** Override Date.now for deterministic tests. */
   now?: () => Date;
 };
@@ -164,6 +198,12 @@ export type RecordResult = {
   pre_filter_rejected: number;
   duplicates_skipped: number;
   passed_to_eval: number;
+  /**
+   * Count of postings staged with `cached_job_evaluation_id` set.
+   * These survive `ready_for_eval_ids` (they still need scoring
+   * against the new criteria) but skip the extract LLM call.
+   */
+  cached_facts_reused: number;
   /** IDs of discovered_postings rows that need full evaluation. */
   ready_for_eval_ids: string[];
 };
@@ -200,24 +240,29 @@ export function recordDiscoveredPostings(
   let inserted_postings = 0;
   let pre_filter_rejected = 0;
   let duplicates_skipped = 0;
+  let cached_facts_reused = 0;
   const ready_for_eval_ids: string[] = [];
 
   for (const posting of options.postings) {
-    // Pre-insert dedup: same (source, external_ref) or url already
-    // staged in a previous run. We still record a fresh row for
-    // search-run accounting but mark it duplicate immediately.
-    const priorByRef =
-      posting.external_ref !== null
-        ? repos.discoveredPostings.findByExternalRef(
-            posting.source,
-            posting.external_ref
-          )
-        : undefined;
-    const priorByUrl =
-      !priorByRef && posting.url !== null
-        ? repos.discoveredPostings.findByUrl(posting.url)
-        : undefined;
-    const prior = priorByRef ?? priorByUrl;
+    // Hash the SYNTHESIZED posting text (the same body the evaluator
+    // would feed to extract) so this matches `job_evaluations.input_hash`
+    // produced by `extractJobFacts`. computePostingInputHash exists
+    // for cases where we want a connector-only canonical hash, but
+    // for cache lookup we need byte-equivalence with extract's hash.
+    const synthText = synthesizePostingText(
+      posting.title,
+      posting.company,
+      posting.raw_metadata
+    );
+    const inputHash = hashPostingText(synthText);
+
+    // Cache lookup: any prior evaluation with the same input_hash AND
+    // extractor_version, regardless of criteria_version_id. We
+    // distinguish three cases below.
+    const priorEval = repos.jobEvaluations.findByInputHash(
+      inputHash,
+      EXTRACTOR_VERSION
+    );
 
     const id = randomUUID();
     repos.discoveredPostings.insert({
@@ -233,21 +278,40 @@ export function recordDiscoveredPostings(
       status: "queued",
       pre_filter_reason_code: null,
       job_evaluation_id: null,
+      cached_job_evaluation_id: null,
+      input_hash: inputHash,
       discovered_at: ts,
       last_seen_at: ts
     });
     inserted_postings += 1;
 
-    if (prior) {
-      duplicates_skipped += 1;
-      // Touch the prior row's last_seen_at so freshness reflects the
-      // re-discovery, then mark this run's row as duplicate and link
-      // its evaluation if known.
-      repos.discoveredPostings.touchLastSeen(prior.id, ts);
-      repos.discoveredPostings.updateStatus(id, "duplicate", {
-        jobEvaluationId: prior.job_evaluation_id ?? undefined
-      });
-      continue;
+    if (priorEval) {
+      const sameCriteria =
+        options.criteriaVersionId !== undefined &&
+        options.criteriaVersionId !== null &&
+        priorEval.criteria_version_id === options.criteriaVersionId;
+      const verdictTerminal =
+        priorEval.verdict !== "needs_review";
+
+      if (sameCriteria && verdictTerminal) {
+        // Branch 1 (same criteria, terminal verdict): skip everything.
+        duplicates_skipped += 1;
+        repos.discoveredPostings.updateStatus(id, "duplicate", {
+          jobEvaluationId: priorEval.id
+        });
+        continue;
+      }
+      // Branch 2 (different criteria, OR same criteria but
+      // needs_review): reuse facts, re-run gates+values+score.
+      cached_facts_reused += 1;
+      // Use raw SQL update via a private path: we need to set
+      // cached_job_evaluation_id on the just-inserted row. The repo's
+      // updateStatus only manages status transitions, not auxiliary
+      // FKs, so we run a one-off statement here.
+      repos.discoveredPostings.setCachedJobEvaluationId(id, priorEval.id);
+      // Posting still goes through pre-extraction gates and (if it
+      // survives) into ready_for_eval_ids; the eval loop checks the
+      // cached_job_evaluation_id column to skip extract.
     }
 
     // Pre-extraction gates over the metadata subset.
@@ -258,7 +322,8 @@ export function recordDiscoveredPostings(
       onsite_locations: posting.onsite_locations,
       is_onsite_required: posting.is_onsite_required,
       employment_type: posting.employment_type,
-      inferred_seniority_signals: posting.inferred_seniority_signals
+      inferred_seniority_signals: posting.inferred_seniority_signals,
+      inferred_role_kinds: posting.inferred_role_kinds
     };
     const gate = preExtractionGateCheck(metadata, options.criteria);
     if (!gate.pass) {
@@ -287,6 +352,7 @@ export function recordDiscoveredPostings(
     inserted_postings,
     pre_filter_rejected,
     duplicates_skipped,
+    cached_facts_reused,
     passed_to_eval: ready_for_eval_ids.length,
     ready_for_eval_ids
   };
@@ -365,11 +431,77 @@ export async function evaluateAllSurvivors(
     }
     const text = synthesizePostingText(row.title, row.company, raw);
 
-    const result = await evaluateJob(
-      options.provider,
-      { text, sourceUrl: row.url ?? undefined },
-      options.criteria
-    );
+    // Reconstruct DiscoveredPostingMetadata from the persisted columns
+    // + raw_metadata so the post-extraction `role_kind` gate has the
+    // same title-classifier values pre-extraction used. We re-run the
+    // classifier here to avoid storing it twice (the alternative is
+    // adding a column on discovered_postings; the regex is cheap so
+    // recomputing is fine). The value is used for gating only.
+    const inferredRoleKinds = inferRoleKindsFromTitle(row.title ?? "");
+    const inferredSeniority = inferSeniorityFromTitle(row.title ?? "");
+    const metadata: DiscoveredPostingMetadata = {
+      title: row.title ?? "",
+      company: row.company ?? "",
+      description_excerpt: extractStringField(raw, "description_excerpt"),
+      onsite_locations: [],
+      is_onsite_required: null,
+      employment_type: null,
+      inferred_seniority_signals: inferredSeniority,
+      inferred_role_kinds: inferredRoleKinds
+    };
+
+    // Cached-facts branch: if a prior evaluation against a different
+    // criteria version produced reusable facts_json, skip the extract
+    // LLM call. The result still gets a fresh job_evaluations row
+    // scoped to the CURRENT criteria_version_id; we only reuse the
+    // expensive extracted facts.
+    let result: EvaluationResult;
+    const cachedEvalId = row.cached_job_evaluation_id;
+    if (cachedEvalId) {
+      const cachedEval = repos.jobEvaluations.findById(cachedEvalId);
+      if (cachedEval) {
+        try {
+          const cachedFacts = JSON.parse(
+            cachedEval.facts_json
+          ) as ExtractedJobFacts;
+          result = await evaluateJobWithCachedFacts(
+            options.provider,
+            {
+              facts: cachedFacts,
+              inputHash: cachedEval.input_hash,
+              extractorVersion: cachedEval.extractor_version
+            },
+            options.criteria,
+            metadata
+          );
+        } catch {
+          // Defensive: malformed facts_json should never happen, but
+          // if it does, fall back to a full re-extract rather than
+          // crashing the run.
+          result = await evaluateJob(
+            options.provider,
+            { text, sourceUrl: row.url ?? undefined },
+            options.criteria,
+            metadata
+          );
+        }
+      } else {
+        // FK pointed to a row that no longer exists. Fall back.
+        result = await evaluateJob(
+          options.provider,
+          { text, sourceUrl: row.url ?? undefined },
+          options.criteria,
+          metadata
+        );
+      }
+    } else {
+      result = await evaluateJob(
+        options.provider,
+        { text, sourceUrl: row.url ?? undefined },
+        options.criteria,
+        metadata
+      );
+    }
 
     // Persist job_evaluations + provider_runs (mirrors
     // apps/mcp-server/src/persistence.ts exactly).

--- a/packages/evaluator/src/__tests__/gates.test.ts
+++ b/packages/evaluator/src/__tests__/gates.test.ts
@@ -158,6 +158,113 @@ describe("hardGateCheck — industry blocklist", () => {
   });
 });
 
+describe("hardGateCheck — role_kind", () => {
+  it("rejects when metadata.inferred_role_kinds overlaps the blocklist", () => {
+    const facts = baseValidFacts({ title: "Account Executive" });
+    const criteria = baseCriteria({
+      hard_gates: {
+        must_have: [],
+        must_not_have: [
+          {
+            kind: "role_kind",
+            any_of: ["sales"],
+            reason: "Targeting engineering"
+          }
+        ],
+        must_not_contain_phrases: []
+      }
+    });
+    const metadata = {
+      title: "Account Executive",
+      company: "Acme",
+      description_excerpt: null,
+      onsite_locations: [],
+      is_onsite_required: false,
+      employment_type: "full_time" as const,
+      inferred_seniority_signals: [],
+      inferred_role_kinds: ["sales" as const]
+    };
+    const reject = expectReject(hardGateCheck(facts, criteria, metadata));
+    assert.equal(reject.gate, "role_kind");
+    assert.equal(reject.reason_code, "hard_gate:role_kind:sales");
+  });
+
+  it("defers when no metadata is provided (manual_paste path)", () => {
+    const facts = baseValidFacts();
+    const criteria = baseCriteria({
+      hard_gates: {
+        must_have: [],
+        must_not_have: [
+          {
+            kind: "role_kind",
+            any_of: ["sales"],
+            reason: "test"
+          }
+        ],
+        must_not_contain_phrases: []
+      }
+    });
+    // No metadata third arg → defer (no rejection).
+    assert.equal(hardGateCheck(facts, criteria).pass, true);
+  });
+
+  it("defers when metadata.inferred_role_kinds is only ['other']", () => {
+    const facts = baseValidFacts();
+    const criteria = baseCriteria({
+      hard_gates: {
+        must_have: [],
+        must_not_have: [
+          {
+            kind: "role_kind",
+            any_of: ["sales"],
+            reason: "test"
+          }
+        ],
+        must_not_contain_phrases: []
+      }
+    });
+    const metadata = {
+      title: "Cosmic Ray Whisperer",
+      company: "Acme",
+      description_excerpt: null,
+      onsite_locations: [],
+      is_onsite_required: false,
+      employment_type: null,
+      inferred_seniority_signals: [],
+      inferred_role_kinds: ["other" as const]
+    };
+    assert.equal(hardGateCheck(facts, criteria, metadata).pass, true);
+  });
+
+  it("passes when role_kind tags do not overlap the blocklist", () => {
+    const facts = baseValidFacts();
+    const criteria = baseCriteria({
+      hard_gates: {
+        must_have: [],
+        must_not_have: [
+          {
+            kind: "role_kind",
+            any_of: ["sales", "marketing"],
+            reason: "engineering only"
+          }
+        ],
+        must_not_contain_phrases: []
+      }
+    });
+    const metadata = {
+      title: "Software Engineer",
+      company: "Acme",
+      description_excerpt: null,
+      onsite_locations: [],
+      is_onsite_required: false,
+      employment_type: "full_time" as const,
+      inferred_seniority_signals: [],
+      inferred_role_kinds: ["engineering" as const]
+    };
+    assert.equal(hardGateCheck(facts, criteria, metadata).pass, true);
+  });
+});
+
 describe("hardGateCheck — required_clearance", () => {
   it("rejects required clearance posting matching the blocklist", () => {
     const facts = baseValidFacts({ required_clearance: "secret" });
@@ -493,10 +600,10 @@ describe("hardGateCheck — execution order", () => {
     assert.deepEqual(reject.gates_evaluated, ["must_not_contain_phrases"]);
   });
 
-  it("pass result lists all 10 gates in canonical order", () => {
+  it("pass result lists all 11 gates in canonical order", () => {
     const result = hardGateCheck(baseValidFacts(), baseCriteria());
     assert.equal(result.pass, true);
-    assert.equal(result.gates_evaluated.length, 10);
+    assert.equal(result.gates_evaluated.length, 11);
     assert.deepEqual(result.gates_evaluated, [...GATE_ORDER]);
   });
 });

--- a/packages/evaluator/src/__tests__/pipeline.test.ts
+++ b/packages/evaluator/src/__tests__/pipeline.test.ts
@@ -1,7 +1,11 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 import type { CandidateCriteria } from "@networkpipeline/criteria";
-import { evaluateJob, MockJsonOutputProvider } from "../index.js";
+import {
+  evaluateJob,
+  evaluateJobWithCachedFacts,
+  MockJsonOutputProvider
+} from "../index.js";
 import { baseValidFacts } from "./fixtures.js";
 
 function baseCriteria(
@@ -257,5 +261,123 @@ describe("evaluateJob — observability", () => {
     assert.equal(out.criteria_version, 42);
     assert.ok(out.input_hash.length > 0);
     assert.equal(out.extractor_version, "extract_v1");
+  });
+});
+
+describe("evaluateJobWithCachedFacts — extract is replaced with synthetic ProviderRun", () => {
+  it("does NOT call the provider for extract; runs gates+values+score", async () => {
+    // Provider only enqueues responses for the soft_score stage —
+    // values_check short-circuits because refusals are empty, and
+    // extract is replaced by the synthetic cached ProviderRun.
+    const provider = new MockJsonOutputProvider([
+      {
+        score: 0.9,
+        contributions: [
+          {
+            topic: "AI/ML evaluation systems",
+            weight: 1.0,
+            contribution: 0.9,
+            rationale: "match"
+          }
+        ],
+        rationale: "Strong"
+      }
+    ]);
+
+    const criteria = baseCriteria();
+    criteria.soft_preferences.positive.push({
+      topic: "AI/ML evaluation systems",
+      weight: 1.0
+    });
+
+    const cachedFacts = baseValidFacts({
+      title: "Research Engineer",
+      company: "Anthropic",
+      industry_tags: ["ai_ml", "research"]
+    });
+
+    const out = await evaluateJobWithCachedFacts(
+      provider,
+      {
+        facts: cachedFacts,
+        inputHash: "deadbeef",
+        extractorVersion: "extract_v1"
+      },
+      criteria
+    );
+
+    assert.equal(out.verdict, "accepted");
+    // 4 ProviderRuns: cached extract + skipped values + scored.
+    assert.equal(out.provider_runs.length, 3);
+    assert.equal(out.provider_runs[0].provider, "cached");
+    assert.equal(out.provider_runs[0].cost_usd_cents, 0);
+    assert.equal(out.provider_runs[0].input_tokens, 0);
+    // Threaded values come from the args.
+    assert.equal(out.input_hash, "deadbeef");
+    assert.equal(out.extractor_version, "extract_v1");
+  });
+
+  it("rejects via hard_gate without burning extract budget", async () => {
+    const provider = new MockJsonOutputProvider([]); // no responses needed
+    const criteria = baseCriteria({
+      hard_gates: {
+        must_have: [],
+        must_not_have: [
+          { kind: "company", any_of: ["Anduril"], reason: "values" }
+        ],
+        must_not_contain_phrases: []
+      }
+    });
+    const cachedFacts = baseValidFacts({ company: "Anduril" });
+    const out = await evaluateJobWithCachedFacts(
+      provider,
+      {
+        facts: cachedFacts,
+        inputHash: "h",
+        extractorVersion: "extract_v1"
+      },
+      criteria
+    );
+    assert.equal(out.verdict, "rejected");
+    assert.equal(out.short_circuited_at_stage, "hard_gate");
+    // Only the synthetic cached extract run; no real provider calls.
+    assert.equal(out.provider_runs.length, 1);
+    assert.equal(out.provider_runs[0].provider, "cached");
+  });
+
+  it("forwards metadata to the role_kind gate", async () => {
+    const provider = new MockJsonOutputProvider([]);
+    const criteria = baseCriteria({
+      hard_gates: {
+        must_have: [],
+        must_not_have: [
+          { kind: "role_kind", any_of: ["sales"], reason: "engineering only" }
+        ],
+        must_not_contain_phrases: []
+      }
+    });
+    const cachedFacts = baseValidFacts({ title: "Account Executive" });
+    const out = await evaluateJobWithCachedFacts(
+      provider,
+      {
+        facts: cachedFacts,
+        inputHash: "h",
+        extractorVersion: "extract_v1"
+      },
+      criteria,
+      {
+        title: "Account Executive",
+        company: "Acme",
+        description_excerpt: null,
+        onsite_locations: [],
+        is_onsite_required: false,
+        employment_type: "full_time",
+        inferred_seniority_signals: [],
+        inferred_role_kinds: ["sales"]
+      }
+    );
+    assert.equal(out.verdict, "rejected");
+    if (out.hard_gate_result.pass) throw new Error("expected reject");
+    assert.equal(out.hard_gate_result.gate, "role_kind");
   });
 });

--- a/packages/evaluator/src/__tests__/pre_extraction.test.ts
+++ b/packages/evaluator/src/__tests__/pre_extraction.test.ts
@@ -74,17 +74,18 @@ function expectReject(
 // ---------- pass-through ----------
 
 describe("preExtractionGateCheck — pass-through", () => {
-  it("passes with all 6 gates evaluated in canonical order when nothing trips", () => {
+  it("passes with all 7 gates evaluated in canonical order when nothing trips", () => {
     const result = preExtractionGateCheck(baseMetadata(), baseCriteria());
     assert.equal(result.pass, true);
     assert.deepEqual(result.gates_evaluated, [...PRE_EXTRACTION_GATES]);
-    assert.equal(result.gates_evaluated.length, 6);
+    assert.equal(result.gates_evaluated.length, 7);
   });
 
-  it("PRE_EXTRACTION_GATES contains exactly the 6 metadata-decidable gates in canonical (GATE_ORDER) order", () => {
+  it("PRE_EXTRACTION_GATES contains exactly the 7 metadata-decidable gates in canonical (GATE_ORDER) order", () => {
     assert.deepEqual([...PRE_EXTRACTION_GATES], [
       "must_not_contain_phrases",
       "company",
+      "role_kind",
       "role_seniority",
       "location_requirement",
       "location_allowed",
@@ -312,6 +313,144 @@ describe("preExtractionGateCheck — employment_type", () => {
   });
 });
 
+// ---------- role_kind ----------
+
+describe("preExtractionGateCheck — role_kind", () => {
+  it("rejects when an inferred role_kind is in the blocklist", () => {
+    const metadata = baseMetadata({
+      title: "Account Executive, Enterprise",
+      inferred_role_kinds: ["sales"]
+    });
+    const criteria = baseCriteria({
+      hard_gates: {
+        must_have: [],
+        must_not_have: [
+          {
+            kind: "role_kind",
+            any_of: ["sales", "marketing"],
+            reason: "Targeting engineering roles"
+          }
+        ],
+        must_not_contain_phrases: []
+      }
+    });
+    const reject = expectReject(preExtractionGateCheck(metadata, criteria));
+    assert.equal(reject.gate, "role_kind");
+    assert.equal(reject.reason_code, "hard_gate:role_kind:sales");
+  });
+
+  it("passes when role_kind is in blocklist but a non-blocked kind also tags", () => {
+    // "Solutions Engineer" tags BOTH sales AND engineering. If the
+    // blocklist contains 'sales' we still reject — ANY blocked kind
+    // is enough. This is the intentional behavior from the spec.
+    // The complementary case: a posting ONLY tagged engineering should
+    // pass even when other kinds (sales) are blocked.
+    const metadata = baseMetadata({
+      title: "Software Engineer",
+      inferred_role_kinds: ["engineering"]
+    });
+    const criteria = baseCriteria({
+      hard_gates: {
+        must_have: [],
+        must_not_have: [
+          {
+            kind: "role_kind",
+            any_of: ["sales", "marketing", "recruiting"],
+            reason: "engineering only"
+          }
+        ],
+        must_not_contain_phrases: []
+      }
+    });
+    assert.equal(preExtractionGateCheck(metadata, criteria).pass, true);
+  });
+
+  it("rejects when ANY tag is blocked (Solutions Engineer with sales blocked)", () => {
+    const metadata = baseMetadata({
+      title: "Solutions Engineer",
+      inferred_role_kinds: ["engineering", "sales"]
+    });
+    const criteria = baseCriteria({
+      hard_gates: {
+        must_have: [],
+        must_not_have: [
+          {
+            kind: "role_kind",
+            any_of: ["sales"],
+            reason: "Targeting engineering"
+          }
+        ],
+        must_not_contain_phrases: []
+      }
+    });
+    const reject = expectReject(preExtractionGateCheck(metadata, criteria));
+    assert.equal(reject.gate, "role_kind");
+  });
+
+  it("passes when overlapping tags are not blocked (Senior Security Engineer with only sales blocked)", () => {
+    const metadata = baseMetadata({
+      title: "Senior Security Engineer",
+      inferred_role_kinds: ["engineering", "security"]
+    });
+    const criteria = baseCriteria({
+      hard_gates: {
+        must_have: [],
+        must_not_have: [
+          {
+            kind: "role_kind",
+            any_of: ["sales"],
+            reason: "Targeting engineering"
+          }
+        ],
+        must_not_contain_phrases: []
+      }
+    });
+    assert.equal(preExtractionGateCheck(metadata, criteria).pass, true);
+  });
+
+  it("defers when inferred_role_kinds is empty", () => {
+    const metadata = baseMetadata({ inferred_role_kinds: [] });
+    const criteria = baseCriteria({
+      hard_gates: {
+        must_have: [],
+        must_not_have: [
+          {
+            kind: "role_kind",
+            any_of: ["sales"],
+            reason: "test"
+          }
+        ],
+        must_not_contain_phrases: []
+      }
+    });
+    assert.equal(preExtractionGateCheck(metadata, criteria).pass, true);
+  });
+
+  it("defers when inferred_role_kinds contains only 'other'", () => {
+    const metadata = baseMetadata({ inferred_role_kinds: ["other"] });
+    const criteria = baseCriteria({
+      hard_gates: {
+        must_have: [],
+        must_not_have: [
+          {
+            kind: "role_kind",
+            any_of: ["sales"],
+            reason: "test"
+          }
+        ],
+        must_not_contain_phrases: []
+      }
+    });
+    assert.equal(preExtractionGateCheck(metadata, criteria).pass, true);
+  });
+
+  it("does nothing when criteria has no role_kind blocklist", () => {
+    const metadata = baseMetadata({ inferred_role_kinds: ["sales"] });
+    const criteria = baseCriteria(); // empty must_not_have
+    assert.equal(preExtractionGateCheck(metadata, criteria).pass, true);
+  });
+});
+
 // ---------- role_seniority ----------
 
 describe("preExtractionGateCheck — role_seniority", () => {
@@ -422,6 +561,7 @@ describe("preExtractionGateCheck — execution order", () => {
     assert.deepEqual(reject.gates_evaluated, [
       "must_not_contain_phrases",
       "company",
+      "role_kind",
       "role_seniority",
       "location_requirement",
       "location_allowed"

--- a/packages/evaluator/src/extract/extract.ts
+++ b/packages/evaluator/src/extract/extract.ts
@@ -35,8 +35,13 @@ const TOOL_DESCRIPTION =
  * Hash the trimmed, lower-cased first 8 KiB of the posting as a dedup key.
  * Uses the first 8 KiB rather than the full text so minor editorial changes
  * (typo fixes, edit footers) don't force re-extraction.
+ *
+ * Exported so the discovery orchestrator can compute the same hash for
+ * its cache lookup BEFORE the LLM extract call — letting it short-circuit
+ * the extract stage when a prior evaluation already produced facts for
+ * this exact posting body.
  */
-function hashPostingText(text: string): string {
+export function hashPostingText(text: string): string {
   const normalized = text.trim().slice(0, 8192).toLowerCase();
   return createHash("sha256").update(normalized).digest("hex");
 }

--- a/packages/evaluator/src/extract/index.ts
+++ b/packages/evaluator/src/extract/index.ts
@@ -14,6 +14,7 @@ export { EXTRACT_PROMPT_ID, EXTRACT_SYSTEM_PROMPT } from "./prompt.js";
 
 export {
   extractJobFacts,
+  hashPostingText,
   type ExtractJobFactsInput,
   type ExtractJobFactsResult
 } from "./extract.js";

--- a/packages/evaluator/src/gates/check.ts
+++ b/packages/evaluator/src/gates/check.ts
@@ -1,5 +1,6 @@
 import type { CandidateCriteria } from "@networkpipeline/criteria";
 import type { ExtractedJobFacts } from "../extract/schema.js";
+import type { DiscoveredPostingMetadata } from "./metadata.js";
 import {
   buildReasonCode,
   GATE_ORDER,
@@ -13,18 +14,25 @@ import {
  *
  * Pure code. No LLM. Same inputs always produce the same output.
  *
- * Runs all 10 gates in the order documented in §6.4, short-circuiting on
+ * Runs all 11 gates in the order documented in §6.4, short-circuiting on
  * the first failure with a stable reason code from §11.
+ *
+ * The optional `metadata` parameter forwards title-classifier values
+ * (notably `inferred_role_kinds`) from the discovery layer. When
+ * provided, the `role_kind` gate uses those tags. When absent (e.g.
+ * the manual-paste path with no title), the gate defers — same
+ * defer-on-ambiguity contract as role_seniority.
  */
 export function hardGateCheck(
   facts: ExtractedJobFacts,
-  criteria: CandidateCriteria
+  criteria: CandidateCriteria,
+  metadata?: DiscoveredPostingMetadata
 ): GateResult {
   const evaluated: GateName[] = [];
 
   for (const gate of GATE_ORDER) {
     evaluated.push(gate);
-    const verdict = runGate(gate, facts, criteria);
+    const verdict = runGate(gate, facts, criteria, metadata);
     if (verdict !== null) {
       return { ...verdict, gates_evaluated: evaluated };
     }
@@ -38,7 +46,8 @@ type GateFailure = Omit<GateRejectResult, "gates_evaluated">;
 function runGate(
   gate: GateName,
   facts: ExtractedJobFacts,
-  criteria: CandidateCriteria
+  criteria: CandidateCriteria,
+  metadata: DiscoveredPostingMetadata | undefined
 ): GateFailure | null {
   switch (gate) {
     case "must_not_contain_phrases":
@@ -47,6 +56,8 @@ function runGate(
       return checkCompanyBlocklist(facts, criteria);
     case "industry":
       return checkIndustryBlocklist(facts, criteria);
+    case "role_kind":
+      return checkRoleKind(metadata, criteria);
     case "required_clearance":
       return checkRequiredClearance(facts, criteria);
     case "role_seniority":
@@ -66,6 +77,46 @@ function runGate(
       throw new Error(`unhandled gate: ${String(_exhaustive)}`);
     }
   }
+}
+
+function checkRoleKind(
+  metadata: DiscoveredPostingMetadata | undefined,
+  criteria: CandidateCriteria
+): GateFailure | null {
+  const conditions = criteria.hard_gates.must_not_have.filter(
+    (c) => c.kind === "role_kind"
+  );
+  if (conditions.length === 0) return null;
+
+  // Defer when no metadata (e.g., manual_paste path, evaluator unit
+  // tests calling hardGateCheck directly without a discovery upstream)
+  // or when the title-classifier returned only "other"/empty.
+  const kinds = metadata?.inferred_role_kinds ?? [];
+  if (kinds.length === 0) return null;
+  const onlyOther = kinds.every((k) => k === "other");
+  if (onlyOther) return null;
+
+  for (const cond of conditions) {
+    const blocked = new Set(cond.any_of);
+    const matched = kinds.find((k) => blocked.has(k));
+    if (matched !== undefined) {
+      return {
+        pass: false,
+        gate: "role_kind",
+        reason_code: buildReasonCode("role_kind", matched),
+        message: `Posting role_kind tags [${kinds.join(
+          ", "
+        )}] overlap the blocklist [${cond.any_of.join(", ")}] (matched: ${matched}). Reason: ${cond.reason}`,
+        details: {
+          posting_role_kinds: kinds,
+          blocked_kinds: cond.any_of,
+          matched_kind: matched,
+          reason: cond.reason
+        }
+      };
+    }
+  }
+  return null;
 }
 
 // ---------- gate implementations ----------

--- a/packages/evaluator/src/gates/metadata.ts
+++ b/packages/evaluator/src/gates/metadata.ts
@@ -1,5 +1,6 @@
 import type {
   EmploymentType,
+  RoleKind,
   SeniorityBand
 } from "@networkpipeline/criteria";
 
@@ -28,4 +29,15 @@ export type DiscoveredPostingMetadata = {
   is_onsite_required: boolean | null;
   employment_type: EmploymentType | null;
   inferred_seniority_signals: SeniorityBand[];
+  /**
+   * Best-effort title-classifier output. Drives the deterministic
+   * `role_kind` gate (see check.ts / pre_extraction.ts). Empty array
+   * or `["other"]` means "title didn't match any kind"; the gate
+   * defers in that case (does NOT reject).
+   *
+   * Optional for backward compatibility with callers that haven't
+   * been updated yet (e.g. unit tests pre-dating the gate). Treated
+   * as `["other"]` (defer) when absent.
+   */
+  inferred_role_kinds?: RoleKind[];
 };

--- a/packages/evaluator/src/gates/pre_extraction.ts
+++ b/packages/evaluator/src/gates/pre_extraction.ts
@@ -30,6 +30,7 @@ import {
 export const PRE_EXTRACTION_GATES: readonly GateName[] = [
   "must_not_contain_phrases",
   "company",
+  "role_kind",
   "role_seniority",
   "location_requirement",
   "location_allowed",
@@ -81,6 +82,8 @@ function runGate(
       return checkPhraseBlocklist(metadata, criteria);
     case "company":
       return checkCompanyBlocklist(metadata, criteria);
+    case "role_kind":
+      return checkRoleKind(metadata, criteria);
     case "location_requirement":
       return checkLocationRequirement(metadata, criteria);
     case "location_allowed":
@@ -100,6 +103,45 @@ function runGate(
       throw new Error(`unhandled gate: ${String(_exhaustive)}`);
     }
   }
+}
+
+function checkRoleKind(
+  metadata: DiscoveredPostingMetadata,
+  criteria: CandidateCriteria
+): GateFailure | null {
+  const conditions = criteria.hard_gates.must_not_have.filter(
+    (c) => c.kind === "role_kind"
+  );
+  if (conditions.length === 0) return null;
+
+  // Defer when title-classifier returned nothing or only "other".
+  // Mirrors role_seniority's defer-on-empty contract.
+  const kinds = metadata.inferred_role_kinds ?? [];
+  if (kinds.length === 0) return null;
+  const onlyOther = kinds.every((k) => k === "other");
+  if (onlyOther) return null;
+
+  for (const cond of conditions) {
+    const blocked = new Set(cond.any_of);
+    const matched = kinds.find((k) => blocked.has(k));
+    if (matched !== undefined) {
+      return {
+        pass: false,
+        gate: "role_kind",
+        reason_code: buildReasonCode("role_kind", matched),
+        message: `Posting role_kind tags [${kinds.join(
+          ", "
+        )}] overlap the blocklist [${cond.any_of.join(", ")}] (matched: ${matched}). Reason: ${cond.reason}`,
+        details: {
+          posting_role_kinds: kinds,
+          blocked_kinds: cond.any_of,
+          matched_kind: matched,
+          reason: cond.reason
+        }
+      };
+    }
+  }
+  return null;
 }
 
 // ---------- gate implementations ----------

--- a/packages/evaluator/src/gates/result.ts
+++ b/packages/evaluator/src/gates/result.ts
@@ -10,6 +10,7 @@
  *   - hard_gate:must_not_contain_phrases:active security clearance required
  *   - hard_gate:company:Anduril
  *   - hard_gate:industry:autonomous_lethal_systems
+ *   - hard_gate:role_kind:sales
  *   - hard_gate:required_clearance:secret
  *   - hard_gate:role_seniority:staff
  *   - hard_gate:location_requirement:Denver, CO
@@ -22,6 +23,7 @@ export type GateName =
   | "must_not_contain_phrases"
   | "company"
   | "industry"
+  | "role_kind"
   | "required_clearance"
   | "role_seniority"
   | "location_requirement"
@@ -33,16 +35,17 @@ export type GateName =
 /**
  * Stable execution order. Cheaper / more decisive gates run first.
  *
- * 1. must_not_contain_phrases — pure substring match, fastest
- * 2. company                  — exact company-name match
- * 3. industry                 — controlled-vocabulary tag match
- * 4. required_clearance       — clearance enum match
- * 5. role_seniority           — band overlap
- * 6. location_requirement     — onsite-location list check
- * 7. work_authorization       — sponsorship-status check
- * 8. location_allowed         — profile.primary_locations match
- * 9. employment_type          — type membership
- * 10. years_experience        — numeric requirement vs profile YOE
+ * 1.  must_not_contain_phrases — pure substring match, fastest
+ * 2.  company                  — exact company-name match
+ * 3.  industry                 — controlled-vocabulary tag match
+ * 4.  role_kind                — title-classifier overlap (deterministic)
+ * 5.  required_clearance       — clearance enum match
+ * 6.  role_seniority           — band overlap
+ * 7.  location_requirement     — onsite-location list check
+ * 8.  work_authorization       — sponsorship-status check
+ * 9.  location_allowed         — profile.primary_locations match
+ * 10. employment_type          — type membership
+ * 11. years_experience         — numeric requirement vs profile YOE
  *
  * Pipeline short-circuits on first failure.
  */
@@ -50,6 +53,7 @@ export const GATE_ORDER: readonly GateName[] = [
   "must_not_contain_phrases",
   "company",
   "industry",
+  "role_kind",
   "required_clearance",
   "role_seniority",
   "location_requirement",
@@ -61,7 +65,7 @@ export const GATE_ORDER: readonly GateName[] = [
 
 export type GatePassResult = {
   pass: true;
-  /** All gates that ran (always all 10 in order on a pass). */
+  /** All gates that ran (always all 11 in order on a pass). */
   gates_evaluated: GateName[];
 };
 

--- a/packages/evaluator/src/pipeline/evaluate.ts
+++ b/packages/evaluator/src/pipeline/evaluate.ts
@@ -4,7 +4,11 @@ import {
   type ExtractedJobFacts,
   type ExtractJobFactsInput
 } from "../extract/index.js";
-import { hardGateCheck, type GateResult } from "../gates/index.js";
+import {
+  hardGateCheck,
+  type DiscoveredPostingMetadata,
+  type GateResult
+} from "../gates/index.js";
 import type { JsonOutputProvider, ProviderRun } from "../provider/types.js";
 import { softScore, type SoftScoreResult } from "../score/index.js";
 import { valuesCheck, type ValuesCheckResult } from "../values/index.js";
@@ -65,7 +69,8 @@ export type EvaluationResult = {
 export async function evaluateJob(
   provider: JsonOutputProvider,
   input: ExtractJobFactsInput,
-  criteria: CandidateCriteria
+  criteria: CandidateCriteria,
+  metadata?: DiscoveredPostingMetadata
 ): Promise<EvaluationResult> {
   const provider_runs: ProviderRun[] = [];
   const stages_run: EvaluationStage[] = [];
@@ -83,8 +88,12 @@ export async function evaluateJob(
   } as const;
 
   // ── Stage 2: hard gates (pure code) ───────────────────────────────
+  // Forward `metadata` so the deterministic role_kind gate can run
+  // post-extraction with the same title-classifier values used by
+  // pre-extraction. When metadata is absent (e.g. evaluate_job called
+  // directly with a manual URL), the role_kind gate defers.
   stages_run.push("hard_gate");
-  const gateResult = hardGateCheck(extracted.facts, criteria);
+  const gateResult = hardGateCheck(extracted.facts, criteria, metadata);
   if (!gateResult.pass) {
     return {
       verdict: "rejected",
@@ -166,5 +175,158 @@ export async function evaluateJob(
     soft_score_result: scoreOut.result,
     provider_runs,
     ...baseShape
+  };
+}
+
+/**
+ * evaluateJobWithCachedFacts — same as `evaluateJob` but skips the
+ * extract stage. Used when an earlier evaluation against a different
+ * criteria version produced compatible `facts_json` (same posting body,
+ * same extractor_version) and we just want to re-run the
+ * gates+values+score stages against the current criteria.
+ *
+ * Cost contract: the extract LLM call is replaced with a synthetic
+ * `provider="cached"` ProviderRun (zero tokens, zero latency, zero
+ * cost) so run accounting stays consistent — `provider_runs.length`
+ * still tracks "stages with provider involvement", just with a $0
+ * placeholder for extract.
+ *
+ * Caller responsibilities:
+ *  - Compute `inputHash` matching `extractJobFacts(...)` so the
+ *    returned EvaluationResult's `input_hash` is correct.
+ *  - Pass the source `extractor_version` so the row's column matches.
+ *  - Pass `metadata` if the role_kind gate should run; otherwise the
+ *    gate defers (consistent with the manual-paste path).
+ */
+export async function evaluateJobWithCachedFacts(
+  provider: JsonOutputProvider,
+  args: {
+    facts: ExtractedJobFacts;
+    inputHash: string;
+    extractorVersion: string;
+  },
+  criteria: CandidateCriteria,
+  metadata?: DiscoveredPostingMetadata
+): Promise<EvaluationResult> {
+  const provider_runs: ProviderRun[] = [];
+  const stages_run: EvaluationStage[] = [];
+
+  // ── Stage 1: extract (CACHED — no provider call) ──────────────────
+  // Synthetic ProviderRun keeps the per-stage accounting shape stable.
+  // We use provider="cached" as a sentinel that orchestrators must
+  // skip when summing cost (mirrors the existing "skipped" handling).
+  stages_run.push("extract");
+  provider_runs.push(makeCachedExtractProviderRun(args.extractorVersion));
+
+  const facts = args.facts;
+  const baseShape = {
+    facts,
+    input_hash: args.inputHash,
+    extractor_version: args.extractorVersion,
+    criteria_version: criteria.version
+  } as const;
+
+  // ── Stage 2: hard gates (pure code) ───────────────────────────────
+  stages_run.push("hard_gate");
+  const gateResult = hardGateCheck(facts, criteria, metadata);
+  if (!gateResult.pass) {
+    return {
+      verdict: "rejected",
+      reason_code: gateResult.reason_code,
+      short_circuited_at_stage: "hard_gate",
+      stages_run,
+      hard_gate_result: gateResult,
+      values_result: null,
+      soft_score_result: null,
+      provider_runs,
+      ...baseShape
+    };
+  }
+
+  // ── Stage 2b: values_check ─────────────────────────────────────────
+  stages_run.push("values_check");
+  const valuesOut = await valuesCheck(provider, { facts, criteria });
+  provider_runs.push(valuesOut.run);
+
+  if (valuesOut.result.decision === "reject") {
+    return {
+      verdict: "rejected",
+      reason_code: valuesOut.result.reason_code,
+      short_circuited_at_stage: "values_check",
+      stages_run,
+      hard_gate_result: gateResult,
+      values_result: valuesOut.result,
+      soft_score_result: null,
+      provider_runs,
+      ...baseShape
+    };
+  }
+  if (valuesOut.result.decision === "needs_review") {
+    return {
+      verdict: "needs_review",
+      reason_code: "values:needs_review",
+      short_circuited_at_stage: "values_check",
+      stages_run,
+      hard_gate_result: gateResult,
+      values_result: valuesOut.result,
+      soft_score_result: null,
+      provider_runs,
+      ...baseShape
+    };
+  }
+
+  // ── Stage 3: soft_score ───────────────────────────────────────────
+  stages_run.push("soft_score");
+  const scoreOut = await softScore(provider, { facts, criteria });
+  provider_runs.push(scoreOut.run);
+
+  if (scoreOut.result.below_threshold) {
+    return {
+      verdict: "below_threshold",
+      reason_code: scoreOut.result.reason_code,
+      short_circuited_at_stage: "soft_score",
+      stages_run,
+      hard_gate_result: gateResult,
+      values_result: valuesOut.result,
+      soft_score_result: scoreOut.result,
+      provider_runs,
+      ...baseShape
+    };
+  }
+
+  return {
+    verdict: "accepted",
+    reason_code: "",
+    short_circuited_at_stage: null,
+    stages_run,
+    hard_gate_result: gateResult,
+    values_result: valuesOut.result,
+    soft_score_result: scoreOut.result,
+    provider_runs,
+    ...baseShape
+  };
+}
+
+/**
+ * Synthetic ProviderRun for the cached-extract code path. Zero tokens,
+ * zero cost, `provider="cached"` so orchestrator cost accumulation can
+ * filter it out the same way it filters `provider="skipped"`.
+ */
+function makeCachedExtractProviderRun(
+  extractorVersion: string
+): ProviderRun {
+  return {
+    provider: "cached",
+    model: "n/a",
+    prompt_id: extractorVersion,
+    started_at: new Date().toISOString(),
+    latency_ms: 0,
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_creation_tokens: 0,
+    cache_read_tokens: 0,
+    cost_usd_cents: 0,
+    stop_reason: "cached",
+    retries: 0
   };
 }

--- a/packages/evaluator/src/pipeline/index.ts
+++ b/packages/evaluator/src/pipeline/index.ts
@@ -1,5 +1,6 @@
 export {
   evaluateJob,
+  evaluateJobWithCachedFacts,
   type EvaluationResult,
   type EvaluationStage,
   type EvaluationVerdict


### PR DESCRIPTION
Three deterministic mechanisms to bring per-search LLM call counts down ~85%. Real-world Anthropic Greenhouse case (443 postings → ~30-50 evaluated) goes from 30-45 minutes to 1-3 minutes.

- **role_kind gate** — title-regex classifier (sales / engineering / ml / etc) feeds a new `must_not_have.role_kind` hard gate. RoleKind enum lives in @networkpipeline/criteria to break dep cycle. ~60-70% of Anthropic's roster rejected pre-extraction.
- **max_results** — nullable column on saved_searches; connectors and orchestrator honor.
- **extraction cache** — `(input_hash, extractor_version)` lookup ignoring criteria_version. Cross-version cache hit reuses facts_json, skips extract LLM call, runs gates+values+score against current criteria. Synthetic provider="cached" run keeps accounting consistent.

Migrations: additive ALTER TABLE wrapped in try/catch swallowing duplicate-column errors. Three new columns: `saved_searches.max_results`, `discovered_postings.cached_job_evaluation_id`, `discovered_postings.input_hash`.

453 tests pass across 5 workspaces. +83 from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)